### PR TITLE
Update keyboard macro input and docs

### DIFF
--- a/docs/keyboard_macro_release.md
+++ b/docs/keyboard_macro_release.md
@@ -1,69 +1,119 @@
-# DMC4 Keyboard Macro + Battle Snapshot
+# DMC4 Keyboard Macro + Battle Snapshot Player Guide
 
-This test build adds a new dmc4_hook control section:
+Read this first if you only want to install the DLL, play a macro, and understand the basic script language. For every accepted command and token, see `keyboard_macro_script_reference.md`.
 
-```text
-Keyboard Macro
-```
+## What This Adds
 
-The page contains two player-facing tools:
+- Keyboard Macro plays scripted DMC4 inputs from `keyboard_macro*.txt`.
+- Battle Snapshot restores a repeatable same-room training setup.
 
-- Keyboard Macro: plays scripted inputs from text files.
-- Battle Snapshot: captures and restores a stable training setup.
+Keyboard Macro is not AHK. It writes into DMC4's input layer instead of sending Windows keyboard events. Timing is based on game input updates, and your normal player input can still be mixed with macro playback.
+
+Battle Snapshot is not a full savestate. It is meant for practical training resets in the same room: player position, camera, and matching active enemies.
 
 ## Install
 
 1. Close the game.
 2. Back up the existing `dinput8.dll` next to `DevilMayCry4_DX9.exe`.
 3. Copy the new `dinput8.dll` next to `DevilMayCry4_DX9.exe`.
-4. Copy `keyboard_macro.txt` to the same folder, or choose a custom macro file in the GUI.
-5. Launch the game and open the dmc4_hook GUI.
-6. Find and enable `Keyboard Macro` in the dmc4_hook GUI. In current upstream builds it appears under `Training`.
+4. Copy `keyboard_macro.txt` to the same folder.
+5. Launch the game.
+6. Open the dmc4_hook GUI.
+7. Enable `Keyboard Macro` under `Training`.
 
-## Macro Files
-
-The GUI automatically lists text files in the game folder whose names match:
-
-```text
-keyboard_macro*.txt
-```
-
-Examples:
+The GUI automatically lists files next to the game executable whose names match `keyboard_macro*.txt`, such as:
 
 ```text
 keyboard_macro.txt
-keyboard_macro1.txt
 keyboard_macro_nero.txt
-keyboard_macro_dante.txt
+keyboard_macro_boss_practice.txt
 ```
 
-Use `Custom Macro File` if the file is somewhere else.
+Use `Custom Macro File` if your file is somewhere else.
 
-## Main Controls
+## First Test
+
+Create or edit `keyboard_macro.txt`:
+
+```text
+[V] Jump test
+TAP JUMP
+```
+
+In game:
+
+1. Enable `Keyboard Macro`.
+2. Select `keyboard_macro.txt`.
+3. Click `Reload Macro File`.
+4. Select `Jump test [V]`.
+5. Press `V` or click `Play Macro`.
+
+Your character should jump once.
+
+## GUI Controls
 
 - `Keyboard Macro`: master enable. When this is off, macro hotkeys and playback do not run.
 - `Macro File`: selects one detected `keyboard_macro*.txt` file.
-- `Custom Macro File`: manually enters a file path.
+- `Custom Macro File`: lets you type or paste a custom path.
 - `Macro Clip`: selects one section from the loaded file.
-- `Hotkeys`: changes the reload, play, stop, capture, load, and load-then-play keys.
-- `Reload Macro File`: reads the selected file again from disk.
+- `Reload Macro File`: reads the selected file again after you edit it.
 - `Play Macro`: starts the selected clip.
 - `Stop Macro`: stops playback and releases macro-held input.
-- `Snapshot Play Delay Ticks`: delay between loading a Battle Snapshot and starting macro playback.
-- `Load Snapshot + Play Macro`: loads the current Battle Snapshot, waits the configured delay, then starts the selected macro clip.
+- `Auto reload Macro file`: reloads the selected file after you save it, as long as playback is not currently running.
+- `Stop Macro when game pauses`: stops playback when DMC4 opens the pause menu, so the macro will not continue after unpausing.
+- `Hotkeys`: sets keys for reload, play, stop, capture snapshot, load snapshot, and load snapshot plus play.
+- `Action Mapping`: tells action names such as `MELEE`, `JUMP`, and `LOCK_ON` which virtual controller buttons they should press.
+- `Snapshot Play Delay Ticks`: delay between loading a snapshot and playing the selected macro.
+- `Load Snapshot + Play Macro`: loads the snapshot, waits the delay, then starts the selected macro clip.
 
-## Input Model
+## Input Names
 
-The macro system writes into the game's input layer instead of sending Windows keyboard events. This is why it is more stable than AHK-style automation:
+For readable scripts, write game action names:
 
-- game focus matters less
-- key timing is tied to game input updates
-- held buttons and releases are represented explicitly
-- your normal input can still be mixed with macro playback
+```text
+MELEE
+GUN
+JUMP
+BRINGER
+STYLE_ACTION
+DEVIL_TRIGGER
+LOCK_ON
+EXCEED
+CHANGE_GUN
+CHANGE_SWORD
+TAUNT
+CHANGE_TARGET
+RESET_CAMERA
+```
 
-Macro files do not press your physical keyboard keys. They describe the game's input buttons and movement directions. For example, use `Y` for melee, `A` for jump, and `EXCEED` for Nero Exceed.
+Action names use `Action Mapping` in the GUI. Match this table to your DMC4 in-game controller settings. The table does not change DMC4's controls by itself; it only tells the macro which virtual controller button to output for each action name.
 
-Movement uses fixed macro direction tokens:
+Example:
+
+```text
+DMC4 option: Lock-On = R2
+Action Mapping: LOCK_ON = RT / R2
+Script: HOLD LOCK_ON
+```
+
+Controller names are also valid:
+
+```text
+Xbox:         Y X A B LB RB LT RT LS RS START BACK
+PlayStation: TRIANGLE SQUARE CROSS CIRCLE L1 R1 L2 R2 L3 R3 OPTIONS SHARE
+```
+
+Important:
+
+- `X` means Xbox X, which is DMC4's default gun button. If you mean PlayStation Cross, write `CROSS`.
+- `A` means Xbox A, which is DMC4's default jump button. If you mean move left, write `MA`.
+- `LS` and `RS` mean physical stick clicks / L3 and R3. Prefer `CHANGE_TARGET` and `RESET_CAMERA` when you mean those actions.
+- If you mean camera movement, write `CAM_LEFT`, `CAM_RIGHT`, `RS_LEFT`, or `RS_RIGHT`.
+- `EXCEED` is the safest spelling for Nero Exceed.
+
+## Movement, Camera, And Ticks
+
+Movement uses virtual left-stick directions:
 
 ```text
 MW = move forward / up
@@ -72,58 +122,115 @@ MA = move left
 MD = move right
 ```
 
-These names are virtual direction aliases. They are not your physical keyboard layout. This matters for AZERTY/ZQSD users: `MA` still means "move left" even if your real left key in DMC4 is `Q`. The short aliases `W`, `S`, `A`, and `D` may work as movement aliases, but shared scripts should prefer `MW/MS/MA/MD` so nobody confuses movement `A` with the game's `A` jump button.
+These names are not physical keyboard keys. On an AZERTY keyboard, your real left key might be `Q`, but macro `MA` still means move left.
 
-`WAIT n` is not milliseconds. It means the current macro input state is held for `n` input ticks. An input tick is one pass through the game's input-reading path. In normal gameplay it is usually close to one rendered frame, so at 60 FPS it feels close to 1/60 second and at 120 FPS it feels close to 1/120 second, but scripts should be written in ticks instead of real-time milliseconds. If the game stalls, pauses, or changes update behavior, real time can drift; the macro is still counting game input updates.
-
-Example:
+Slow walk uses a light left-stick push:
 
 ```text
-HOLD Y
+WALK_MW = slow walk forward / up
+WALK_MS = slow walk back / down
+WALK_MA = slow walk left
+WALK_MD = slow walk right
+```
+
+`SLOW_MW`, `SLOW_MS`, `SLOW_MA`, and `SLOW_MD` are equivalent names. You can hold and release them like normal movement:
+
+```text
+HOLD WALK_MD
+WAIT 30
+RELEASE WALK_MD
+```
+
+Camera movement uses virtual right-stick directions:
+
+```text
+CAM_UP
+CAM_DOWN
+CAM_LEFT
+CAM_RIGHT
+```
+
+`WAIT n` uses input ticks, not milliseconds. One tick is one pass through DMC4's input update path. In normal play it is usually close to one rendered frame:
+
+```text
+60 FPS  -> about 1/60 second per tick
+120 FPS -> about 1/120 second per tick
+```
+
+Fastest normal tap in long form:
+
+```text
+HOLD MELEE
 WAIT 1
-RELEASE Y
+RELEASE MELEE
 ```
 
-This means "hold melee through one game input update", not "hold Y for 1 ms".
+If you pause the game while a macro is playing, DMC4 stops running the input updates that advance the macro. With `Stop Macro when game pauses` enabled, the macro is cancelled instead of waiting and continuing after you unpause.
 
-## Character Notes
+## Common Script Helpers
 
-Common default pad labels:
-
-```text
-Y  = melee
-X  = gun
-A  = jump
-B  = Nero Bringer / Dante style action
-L1 = Devil Trigger
-R1 = lock-on
-L2 = Nero Exceed / Dante change gun
-R2 = Dante change sword
-```
-
-These labels refer to the game's default in-game action mapping, not your physical keyboard keys. You can still change the game's own keyboard controls in the normal DMC4 options menu and keep playing with your personal layout. Macro scripts should describe the game action button (`Y` for melee, `A` for jump, `EXCEED` for Nero Exceed, etc.), and the game will resolve that through its current control settings.
-
-For Nero Exceed, prefer:
+`TAP` presses and releases an input:
 
 ```text
+TAP JUMP
 TAP EXCEED
+TAP MELEE 3
 ```
 
-`L2` is also treated as Exceed while playing as Nero. While playing as Dante, `L2` remains the normal change-gun button.
+`DIR direction action ticks` is for one-direction attacks:
+
+```text
+HOLD LOCK_ON
+DIR MA MELEE 1
+RELEASE LOCK_ON
+```
+
+`BACK_FORWARD back forward action` is for moves that need back, then forward, then attack:
+
+```text
+HOLD LOCK_ON
+BACK_FORWARD MD MA MELEE
+RELEASE LOCK_ON
+```
+
+Built-in Nero helpers:
+
+```text
+CALIBUR_RIGHT
+CALIBUR_LEFT
+SHUFFLE_RIGHT
+SHUFFLE_LEFT
+```
+
+Dante style can be set directly:
+
+```text
+STYLE SM
+STYLE GS
+STYLE TS
+STYLE RG
+STYLE DS
+```
+
+If hook `Character Switcher` is already enabled and ready, a macro can request one swap:
+
+```text
+CHARACTER_SWITCH
+```
+
+One Hit Kill can be controlled from a macro:
+
+```text
+ONE_HIT_KILL ON
+ONE_HIT_KILL OFF
+ONE_HIT_KILL TOGGLE
+```
+
+For the full command list, see `keyboard_macro_script_reference.md`.
 
 ## Battle Snapshot
 
-Battle Snapshot is for quickly restoring a training setup in the same room. It is not a full savestate.
-
-`Load Snapshot + Play Macro` is a convenience action for repeatable setup practice. It does this:
-
-```text
-Load Battle Snapshot
-wait Snapshot Play Delay Ticks
-Play selected Macro Clip
-```
-
-Use it when you want one hotkey to reset player/enemy/camera position and immediately test the same macro again. If playback starts before the scene has visually settled, increase `Snapshot Play Delay Ticks`; values like 30 to 100 ticks are reasonable starting points.
+Battle Snapshot is for quickly restoring a training setup in the same mission and room.
 
 The stable restore path covers:
 
@@ -140,38 +247,24 @@ The stable restore path covers:
 - Dante style
 - Royalguard/revenge/disaster-related gauges when available
 
-Use Battle Snapshot in the same mission and room. Loading after changing rooms, restarting a stage, or changing the enemy set may fail or do nothing.
+It is not designed for changing rooms, changing enemy sets, restarting missions, or preserving every animation/model detail.
 
-## Helper Command Quick Guide
-
-`DIR direction button ticks` is for one-direction attacks. It temporarily holds the direction plus the button, then releases them. If `R1` or another input is already held, it stays held during the helper.
+`Load Snapshot + Play Macro` performs:
 
 ```text
-HOLD R1
-DIR MA Y 1
-RELEASE R1
+Load Battle Snapshot
+wait Snapshot Play Delay Ticks
+Play selected Macro Clip
 ```
 
-`BACK_FORWARD back forward button` is for moves that need a back-to-forward input before the attack button, such as Nero Calibur/Shuffle-style inputs. It is not a replacement for every backward move; if the move only needs back plus attack, use `DIR` instead.
+Use it when you want one hotkey to reset position/camera/enemy setup and immediately test the same macro again. If playback starts too early after loading, increase `Snapshot Play Delay Ticks`.
 
-```text
-HOLD R1
-BACK_FORWARD MD MA Y
-RELEASE R1
-```
+## Troubleshooting
 
-## Testing Checklist
-
-For first-time testing:
-
-1. Enable `Keyboard Macro`.
-2. Select `keyboard_macro.txt`.
-3. Click `Reload Macro File`.
-4. Select a clip.
-5. Click `Play Macro`.
-6. Test the hotkey for that clip.
-7. Capture a Battle Snapshot.
-8. Move the player or enemy.
-9. Load the Battle Snapshot.
-
-If something gets stuck, click `Stop Macro` or disable `Keyboard Macro`.
+- Clip does nothing: enable `Keyboard Macro`, reload the file, and check the selected clip.
+- Hotkey does nothing: make sure `Keyboard Macro` is enabled and the hotkey is set in the GUI.
+- Input stays held: click `Stop Macro`.
+- Exceed becomes Bringer: use `EXCEED` and update to the newest DLL from this release.
+- Camera does not move: use `CAM_LEFT` or `RS_LEFT`, not plain `RS`.
+- Target does not change: use `CHANGE_TARGET` while locked on, and make sure Action Mapping matches your in-game controller settings.
+- Snapshot load looks wrong: recapture in the same room, with the same enemy setup, and avoid loading during room transitions.

--- a/docs/keyboard_macro_script_reference.md
+++ b/docs/keyboard_macro_script_reference.md
@@ -1,94 +1,91 @@
 # keyboard_macro*.txt Script Reference
 
-Macro files are plain text. Blank lines are ignored. Lines starting with `#` are comments.
+This is the command and token reference for Keyboard Macro scripts. For install steps, GUI controls, Action Mapping setup, and Battle Snapshot usage, read `keyboard_macro_release.md`.
 
-## Basic Format
-
-The script is state-based:
+## File Format
 
 ```text
-HOLD Y
-WAIT 1
-RELEASE Y
+# comments are ignored
+
+[V] Optional clip hotkey and clip name
+command
+command
+
+[Ctrl+1] Another clip
+command
 ```
 
-This means:
+Rules:
 
-- press `Y`
-- keep that state for 1 input tick
-- release `Y`
+- blank lines are ignored
+- lines starting with `#` are comments
+- write one command per line
+- clip headers are optional, but recommended
+- clip hotkeys start clips only; GUI hotkeys are configured in the GUI
+- macro commands inject DMC4 game input, not Windows keyboard events
 
-Macro scripts describe game inputs, not physical keyboard keys. `Y` means the game's melee button label, `A` means jump, `R1` means lock-on, and so on. Movement should be written with the macro movement tokens explained below, especially `MW`, `MS`, `MA`, and `MD`.
+## Action Tokens
 
-`WAIT` uses input ticks, not milliseconds. One tick means one pass through the game's input update path. In normal play it is usually close to one rendered frame: about 1/60 second at 60 FPS, or about 1/120 second at 120 FPS. It is still better to think in "input updates" instead of real time, because this system is tied to the game's input layer. Real time can vary if the game stalls or pauses, but a macro tick still means one game input update.
-
-## Clips and Hotkeys
-
-A file can contain multiple clips. A clip starts with:
+Action tokens are readable names for DMC4 actions. They use the GUI `Action Mapping` settings.
 
 ```text
-[hotkey] clip name
+MELEE
+GUN
+JUMP
+BRINGER
+STYLE_ACTION
+DEVIL_TRIGGER
+LOCK_ON
+EXCEED
+CHANGE_GUN
+CHANGE_SWORD
+TAUNT
+CHANGE_TARGET
+RESET_CAMERA
 ```
 
-Examples:
+Use these names when possible:
 
 ```text
-[V] Right Calibur
-CALIBUR_RIGHT
-
-[Ctrl+1] Split
-DIR MA Y 1
-
-[Shift+F] Jump shot
-TAP A
-WAIT 1
-TAP X
-```
-
-The clip name can use English, Chinese, or any text that helps you identify it.
-
-The GUI hotkey `Load Snapshot + Play Macro` is separate from clip hotkeys. It loads the current Battle Snapshot, waits `Snapshot Play Delay Ticks`, then starts the selected clip. Do not try to write `TAP F9` or another Windows hotkey in a macro file to control the GUI; macro files inject game inputs, not Windows key events.
-
-## Buttons
-
-Supported button names:
-
-```text
-A B X Y
-L1 R1 L2 R2
-START PAUSE MENU OPTIONS ESC ESCAPE
-SELECT BACK
-L3 R3
-UP DOWN LEFT RIGHT
-EXCEED EX REV MAX_ACT MAXACT
-```
-
-Default DMC4 meanings:
-
-```text
-Y  melee
-X  gun
-A  jump
-B  Nero Bringer / Dante style action
-L1 Devil Trigger
-R1 lock-on
-L2 Nero Exceed / Dante change gun
-R2 Dante change sword
-```
-
-These are the game's default action labels. They are not meant to force you to use the default keyboard layout. If you changed DMC4's keyboard bindings in the game options, keep using your own layout; the macro file still names the in-game action buttons.
-
-For Nero Exceed, `EXCEED` is the clearest spelling:
-
-```text
+TAP JUMP
+HOLD LOCK_ON
+TAP MELEE
 TAP EXCEED
 ```
 
-## Movement
+`EXCEED` is the Nero Exceed action. Direct `L2` / `LT` is also accepted for default Nero controls, but `EXCEED` is clearer.
 
-Movement uses left-stick style directions. Do not write `HOLD W`, `HOLD S`, `HOLD A`, or `HOLD D` expecting physical keyboard keys. Use the explicit movement tokens below.
+## Default Controller Layout
 
-Recommended movement tokens:
+```text
+Action             Xbox        PlayStation
+MELEE             Y           TRIANGLE
+GUN               X           SQUARE
+JUMP              A           CROSS
+BRINGER           B           CIRCLE
+STYLE_ACTION      B           CIRCLE
+DEVIL_TRIGGER     LB          L1
+LOCK_ON           RB          R1
+EXCEED            LT          L2
+CHANGE_GUN        LT          L2
+CHANGE_SWORD      RT          R2
+TAUNT             BACK        SHARE
+CHANGE_TARGET     LS          L3
+RESET_CAMERA      RS          R3
+```
+
+If you changed DMC4's in-game controller settings, match the GUI `Action Mapping` table to your layout. Action Mapping only changes what the macro outputs; it does not change DMC4's own settings.
+
+Important token differences:
+
+- `X` means Xbox X / gun. PlayStation Cross is `CROSS`.
+- `A` means Xbox A / jump. Movement left is `MA`.
+- `LS` and `RS` mean physical stick clicks / L3 and R3. Prefer `CHANGE_TARGET` and `RESET_CAMERA` when you mean those actions.
+- right-stick camera movement uses `CAM_LEFT`, `CAM_RIGHT`, `RS_LEFT`, or `RS_RIGHT`.
+
+## Movement Tokens
+
+Movement tokens are virtual left-stick directions, not physical keyboard keys.
 
 ```text
 MW = move forward / up
@@ -97,98 +94,200 @@ MA = move left
 MD = move right
 ```
 
-Single directions:
+Diagonals:
 
 ```text
-MW W FORWARD MOVE_UP
-MS S BACK BACKWARD MOVE_DOWN
-MA A MOVE_LEFT
-MD D MOVE_RIGHT
+MW_MD
+MW_MA
+MS_MD
+MS_MA
 ```
 
-The short aliases `W`, `S`, `A`, and `D` are accepted only as convenience aliases for movement tokens. They are not physical keyboard key presses, and they can be confusing next to the game button `A` for jump. For clarity, prefer `MW`, `MS`, `MA`, and `MD` in shared scripts and documentation.
-
-This naming is fixed even if your real keyboard layout is not WASD. For example, on an AZERTY keyboard, your real in-game left key might be `Q`, but macro `MA` still means move left. Think of `MW/MS/MA/MD` as virtual left-stick directions, not keyboard letters.
-
-Diagonal directions:
+Descriptive aliases:
 
 ```text
-MW_MD MOVE_UP_RIGHT
-MW_MA MOVE_UP_LEFT
-MS_MD MOVE_DOWN_RIGHT
-MS_MA MOVE_DOWN_LEFT
+MOVE_UP
+MOVE_DOWN
+MOVE_LEFT
+MOVE_RIGHT
+MOVE_FORWARD
+MOVE_BACK
+MOVE_UP_RIGHT
+MOVE_UP_LEFT
+MOVE_DOWN_RIGHT
+MOVE_DOWN_LEFT
 ```
 
-These names are keyboard-like aliases. For lock-on attacks, use the direction relative to the enemy on screen, just like normal play.
+Slow walk tokens use a light left-stick push:
 
-## Commands
+```text
+WALK_MW
+WALK_MS
+WALK_MA
+WALK_MD
+WALK_UP
+WALK_DOWN
+WALK_LEFT
+WALK_RIGHT
+```
+
+`SLOW_*` is accepted as an equivalent spelling, for example `SLOW_MA`.
+
+Slow diagonals:
+
+```text
+WALK_MW_MD
+WALK_MW_MA
+WALK_MS_MD
+WALK_MS_MA
+WALK_UP_RIGHT
+WALK_UP_LEFT
+WALK_DOWN_RIGHT
+WALK_DOWN_LEFT
+```
+
+## Camera Tokens
+
+Right-stick camera movement:
+
+```text
+CAM_UP
+CAM_DOWN
+CAM_LEFT
+CAM_RIGHT
+RS_UP
+RS_DOWN
+RS_LEFT
+RS_RIGHT
+RIGHT_STICK_UP
+RIGHT_STICK_DOWN
+RIGHT_STICK_LEFT
+RIGHT_STICK_RIGHT
+```
+
+Diagonals:
+
+```text
+CAM_UP_LEFT
+CAM_UP_RIGHT
+CAM_DOWN_LEFT
+CAM_DOWN_RIGHT
+RS_UP_LEFT
+RS_UP_RIGHT
+RS_DOWN_LEFT
+RS_DOWN_RIGHT
+```
+
+Right-stick click:
+
+```text
+TAP RESET_CAMERA
+TAP RS
+TAP R3
+```
+
+## D-pad And Style Tokens
+
+```text
+UP
+DOWN
+LEFT
+RIGHT
+STYLE_SM
+STYLE_GS
+STYLE_TS
+STYLE_RG
+STYLE_DS
+```
+
+For direct Dante style switching, prefer the `STYLE` command.
+
+## Timing
+
+`WAIT n` uses DMC4 input ticks, not milliseconds.
+
+```text
+HOLD MELEE
+WAIT 1
+RELEASE MELEE
+```
+
+This is the normal fastest long-form tap. Without `WAIT 1`, the game may not see the input as held.
+
+## Basic Commands
+
+### TAP
+
+```text
+TAP input
+TAP input ticks
+```
+
+Examples:
+
+```text
+TAP MELEE
+TAP JUMP
+TAP EXCEED
+TAP MELEE 3
+```
 
 ### HOLD
 
-Holds one or more inputs until released.
+```text
+HOLD input
+HOLD input+input
+```
+
+Examples:
 
 ```text
-HOLD R1
-HOLD MD
-HOLD Y
-WAIT 1
-RELEASE Y
-RELEASE MD
-RELEASE R1
+HOLD LOCK_ON
+HOLD MA
+HOLD LOCK_ON+MA
 ```
 
 ### RELEASE
 
-Releases one or more inputs.
-
 ```text
-RELEASE Y
-RELEASE R1+MD
+RELEASE input
+RELEASE input+input
 RELEASE ALL
 ```
 
-### TAP
-
-Presses an input for a short number of ticks, then releases it.
+Examples:
 
 ```text
-TAP Y
-TAP Y 3
-TAP EXCEED
+RELEASE MELEE
+RELEASE LOCK_ON+MA
+RELEASE ALL
 ```
-
-`TAP Y` is equivalent to a 1-tick tap.
 
 ### WAIT
 
-Keeps the current held input state for a fixed number of input ticks.
+```text
+WAIT ticks
+```
+
+Example:
 
 ```text
 WAIT 10
 ```
 
-`WAIT 10` means "keep the current macro state for 10 input updates". It does not mean 10 ms.
+### SET
 
-Examples:
-
-```text
-HOLD Y
-RELEASE Y
-```
-
-Without a `WAIT`, the hold and release happen in the same macro step, so the game may never see a real held input.
+Clears the current macro-held state, then holds the new input.
 
 ```text
-HOLD Y
-WAIT 1
-RELEASE Y
+SET LOCK_ON+MA
+WAIT 5
+RELEASE ALL
 ```
-
-With `WAIT 1`, the game gets one input update where `Y` is held. This is the normal form for the fastest tap.
 
 ### CLEAR
 
-Clears held macro input.
+Stops holding all macro-held input.
 
 ```text
 CLEAR
@@ -198,45 +297,43 @@ CLEAR
 
 ### DIR
 
-Direction plus button for a fixed number of ticks. Use this for simple directional attacks where the game only needs one direction plus one button.
-
 ```text
-DIR MA Y 1
+DIR direction action ticks
 ```
 
-This means hold left plus melee for 1 tick, then release both.
+Temporarily holds a direction and an action, then releases only those inputs.
 
-Equivalent long form:
+```text
+HOLD LOCK_ON
+DIR MA MELEE 1
+RELEASE LOCK_ON
+```
+
+Equivalent core input:
 
 ```text
 HOLD MA
-HOLD Y
+HOLD MELEE
 WAIT 1
-RELEASE Y
+RELEASE MELEE
 RELEASE MA
 ```
 
-`DIR` only touches the direction and button you give it. Inputs that were already held stay held during the helper. For example, if you write this:
-
-```text
-HOLD R1
-DIR MA Y 1
-RELEASE R1
-```
-
-then `R1` stays held while the `DIR` helper performs left plus melee.
-
-Use `DIR` for one-direction command moves such as Dante Split, Stinger, High Time, or Full House, depending on the character, weapon, air/ground state, and which direction is correct for your lock-on situation.
-
 ### BACK_FORWARD
 
-Back, then forward, then button. Use this for two-direction command moves where the game expects a back-to-forward input before the attack button.
-
 ```text
-BACK_FORWARD MD MA Y
+BACK_FORWARD back forward action
 ```
 
-Equivalent long form:
+Performs back, then forward, then taps the action.
+
+```text
+HOLD LOCK_ON
+BACK_FORWARD MD MA MELEE
+RELEASE LOCK_ON
+```
+
+Equivalent core input:
 
 ```text
 HOLD MD
@@ -245,16 +342,12 @@ HOLD MA
 RELEASE MD
 WAIT 1
 RELEASE MA
-HOLD Y
+HOLD MELEE
 WAIT 1
-RELEASE Y
+RELEASE MELEE
 ```
 
-The first direction is held for 1 tick, then the second direction is held for 1 tick, then the button is tapped. Like `DIR`, it preserves other inputs that were already held, such as `R1`.
-
-`BACK_FORWARD` is not a replacement for every "backward" move. If a move only needs one back direction plus an attack button, use `DIR <back direction> <button> <ticks>` instead. Use `BACK_FORWARD` for moves like Nero Calibur/Shuffle-style inputs that really need back, then forward, then attack.
-
-### Built-in Nero Helpers
+### Nero Helpers
 
 ```text
 CALIBUR_RIGHT
@@ -263,11 +356,9 @@ SHUFFLE_RIGHT
 SHUFFLE_LEFT
 ```
 
-Use the right/left version that matches your enemy-facing situation.
+Use the version that matches the current facing/enemy direction.
 
-## Dante Style
-
-Use `STYLE` to force Dante's current style directly:
+## Dante Style Command
 
 ```text
 STYLE SM
@@ -277,14 +368,17 @@ STYLE RG
 STYLE DS
 ```
 
-Aliases:
+Full names:
 
 ```text
-FORCE_STYLE RG
-SET_STYLE 3
+STYLE SWORDMASTER
+STYLE GUNSLINGER
+STYLE TRICKSTER
+STYLE ROYALGUARD
+STYLE DARKSLAYER
 ```
 
-Style numbers:
+Numbers:
 
 ```text
 0 SM
@@ -294,11 +388,15 @@ Style numbers:
 4 DS
 ```
 
-This avoids accidentally toggling into Dark Slayer by pressing the same D-pad style input twice.
+`STYLE RG` sets the style directly. To press the D-pad style input normally, use `TAP STYLE_RG` or `TAP DOWN`.
 
 ## Conditional Wait
 
-Conditional wait pauses the macro until a simple game-readable condition becomes true.
+```text
+WAIT_UNTIL condition max_ticks
+```
+
+Supported conditions:
 
 ```text
 WAIT_UNTIL ENEMY_STEP 120
@@ -311,25 +409,23 @@ WAIT_UNTIL LOCKED_ON 120
 WAIT_UNTIL STYLE RG 120
 ```
 
-The final number is the maximum number of input ticks to wait. If the condition becomes true earlier, playback continues immediately. If the number is omitted, playback waits indefinitely.
+If the condition becomes true earlier, playback continues immediately. If `max_ticks` is omitted, playback can wait indefinitely.
 
-Practical examples:
+Examples:
 
 ```text
-TAP Y
+TAP MELEE
 WAIT_UNTIL HIT_CONFIRMED 120
-TAP A
+TAP JUMP
 ```
 
 ```text
 CALIBUR_RIGHT
 WAIT_UNTIL ENEMY_STEP 120
-TAP A
+TAP JUMP
 ```
 
 ## Screen Freeze
-
-Screen freeze pauses the game simulation visually for observation.
 
 ```text
 FREEZE
@@ -337,53 +433,91 @@ WAIT 30
 UNFREEZE
 ```
 
-Toggle form:
+Toggle:
 
 ```text
 TOGGLE_FREEZE
 ```
 
-## Examples
-
-### Nero Exceed Tap
+## Character Switcher
 
 ```text
-[F1] Exceed tap
+CHARACTER_SWITCH
+SWITCH_CHARACTER
+```
+
+This requests one Character Switcher swap. It does not enable Character Switcher by itself.
+
+Requirements:
+
+- enable `Character Switcher` in the hook GUI before entering the stage
+- wait until both characters have been created by Character Switcher
+- do not use it in missions or moments where Character Switcher itself is unsafe
+
+If Character Switcher is not enabled or ready, the command does nothing and the Macro status line reports it.
+
+## Hook Actions
+
+One Hit Kill:
+
+```text
+ONE_HIT_KILL ON
+ONE_HIT_KILL OFF
+ONE_HIT_KILL TOGGLE
+OHK TOGGLE
+```
+
+`ON` enables One Hit Kill, `OFF` disables it, and `TOGGLE` flips the current setting.
+
+## Short Examples
+
+Nero Exceed:
+
+```text
+[F1] Exceed
 TAP EXCEED
 ```
 
-### Nero Right Calibur
+Nero Right Calibur:
 
 ```text
 [V] Right Calibur
-CALIBUR_RIGHT
+HOLD LOCK_ON
+BACK_FORWARD MD MA MELEE
+RELEASE LOCK_ON
 ```
 
-### Dante Split
+Dante Split:
 
 ```text
 [Ctrl+1] Split
-HOLD R1
-HOLD MA
-HOLD Y
-WAIT 1
-RELEASE Y
-RELEASE MA
-RELEASE R1
+HOLD LOCK_ON
+DIR MA MELEE 1
+RELEASE LOCK_ON
 ```
 
-### Dante Style Then Action
+Dante Royalguard action:
 
 ```text
 [F2] RG action
 STYLE RG
 WAIT 1
-TAP B
+TAP STYLE_ACTION
 ```
 
-## Troubleshooting
+Camera left:
 
-- If a clip does nothing, click `Reload Macro File` and check the selected `Macro Clip`.
-- If an input stays held, click `Stop Macro`.
-- If hotkeys do nothing, make sure `Keyboard Macro` is enabled.
-- If Nero Exceed behaves like Bringer, use a build where `EXCEED` and Nero `L2` use the dedicated Exceed path.
+```text
+[F3] Camera left
+HOLD CAM_LEFT
+WAIT 20
+RELEASE CAM_LEFT
+```
+
+## Script Troubleshooting
+
+- Invalid token: check spelling and reload the macro file.
+- Exceed becomes Bringer: use `EXCEED`.
+- Camera does not move: use `CAM_LEFT` / `RS_LEFT`, not plain `RS`.
+- Target does not change: use `CHANGE_TARGET` while locked on, and make sure Action Mapping matches your in-game controller settings.
+- Directional move comes out on the wrong side: swap `MA` and `MD`, or swap `MW` and `MS`.

--- a/src/mods/CharSwitcher.cpp
+++ b/src/mods/CharSwitcher.cpp
@@ -20,6 +20,8 @@ uint32_t kbInput                        = 70; // F
 bool kbInputPressed                     = false;
 int16_t prevInput                       = 0;
 float SSwordRange                       = 26.0f;
+uint32_t macroSwitchRequestTicks        = 0;
+constexpr uint32_t MACRO_SWITCH_REQUEST_TICKS = 8;
 
 uintptr_t CharSwitcher::jmp_ret2 = NULL;
     constexpr uintptr_t detour2_call1 = 0x008DF530;
@@ -552,6 +554,19 @@ naked void Switch(void) {
     }
 }
 
+bool CharSwitcher::request_macro_switch() {
+    if (!mod_enabled) {
+        return false;
+    }
+
+    macroSwitchRequestTicks = std::max(macroSwitchRequestTicks, MACRO_SWITCH_REQUEST_TICKS);
+    return true;
+}
+
+void CharSwitcher::clear_macro_switch_request() {
+    macroSwitchRequestTicks = 0;
+}
+
 // Swap actor
 naked void SwapActor_Controller(void) {
     _asm {
@@ -624,10 +639,14 @@ naked void SwapActor_KB(void) {
             xor eax,eax
             call devil4_sdk::internal_kb_check
             test al,al
+            jne inputPass
+            cmp dword ptr [macroSwitchRequestTicks], 0
             je inputFail
+        inputPass:
             cmp byte ptr [kbInputPressed], 1
             je loopend
             mov byte ptr [kbInputPressed], 1
+            mov dword ptr [macroSwitchRequestTicks], 0
             call Switch
             jmp loopend
         inputFail:
@@ -725,6 +744,9 @@ void CharSwitcher::on_frame(fmilliseconds& dt) {
     if (mod_enabled) {
         SwapActor_Controller();
         SwapActor_KB();
+    }
+    if (macroSwitchRequestTicks > 0) {
+        --macroSwitchRequestTicks;
     }
 }
 

--- a/src/mods/CharSwitcher.hpp
+++ b/src/mods/CharSwitcher.hpp
@@ -21,6 +21,8 @@ public:
 	
     void toggle(bool enable);
     void toggle2(bool enable);
+    static bool request_macro_switch();
+    static void clear_macro_switch_request();
 
     std::string get_mod_name() override { return "CharSwitcher"; };
     std::optional<std::string> on_initialize() override;

--- a/src/mods/InputStates.cpp
+++ b/src/mods/InputStates.cpp
@@ -132,6 +132,15 @@ naked void detour2() { // inputonpress // touchpad ecstasy // player is in edx /
         pop eax
         jne jmpret
 
+        push ecx
+        push eax
+        push edx
+        push edx
+        call KeyboardMacro::on_player_input_press_written
+        pop edx
+        pop eax
+        pop ecx
+
         cmp dword ptr [edx+0x1494], 0 // dante controller id
         jne jmpret
 

--- a/src/mods/KeyboardMacro.cpp
+++ b/src/mods/KeyboardMacro.cpp
@@ -1,6 +1,8 @@
 #include "KeyboardMacro.hpp"
+#include "CharSwitcher.hpp"
 #include "EnemyStepDisplay.hpp"
 #include "EnemyTracker.hpp"
+#include "HealthSettings.hpp"
 #include "WorkRate.hpp"
 
 #include <algorithm>
@@ -28,6 +30,7 @@ namespace {
 constexpr uint32_t MAX_PLAYBACK_FRAMES = 600000;
 constexpr short ANALOG_MIN = -127;
 constexpr short ANALOG_MAX = 127;
+constexpr short ANALOG_WALK = 80;
 constexpr uintptr_t S_DEVIL4_PAD_PTR = 0x00e559c4;
 constexpr uintptr_t S_KEYBOARD_PTR = 0x00e559c0;
 constexpr uintptr_t S_SAVE_PTR = 0x00e558c8;
@@ -43,6 +46,46 @@ constexpr uint32_t PAD_BUTTON_R2 = 0x0800;
 constexpr uint32_t PAD_BUTTON_SELECT = 0x0001;
 constexpr uint32_t PAD_BUTTON_L3 = 0x0002;
 constexpr uint32_t PAD_BUTTON_R3 = 0x0004;
+constexpr uint32_t PAD_BUTTON_START = 0x0008;
+constexpr uint32_t PAD_BUTTON_DPAD_UP = 0x0010;
+constexpr uint32_t PAD_BUTTON_DPAD_RIGHT = 0x0020;
+constexpr uint32_t PAD_BUTTON_DPAD_DOWN = 0x0040;
+constexpr uint32_t PAD_BUTTON_DPAD_LEFT = 0x0080;
+constexpr uint32_t PAD_BUTTON_Y = 0x1000;
+constexpr uint32_t PAD_BUTTON_B = 0x2000;
+constexpr uint32_t PAD_BUTTON_A = 0x4000;
+constexpr uint32_t PAD_BUTTON_X = 0x8000;
+constexpr uint32_t PAD_BUTTON_GLOBAL_ROUTE_MASK = PAD_BUTTON_L3 | PAD_BUTTON_R3;
+enum MacroActionIndex : uint32_t {
+    MACRO_ACTION_MELEE = 0,
+    MACRO_ACTION_GUN,
+    MACRO_ACTION_JUMP,
+    MACRO_ACTION_BRINGER,
+    MACRO_ACTION_STYLE_ACTION,
+    MACRO_ACTION_DEVIL_TRIGGER,
+    MACRO_ACTION_LOCK_ON,
+    MACRO_ACTION_CHANGE_GUN,
+    MACRO_ACTION_CHANGE_SWORD,
+    MACRO_ACTION_TAUNT,
+    MACRO_ACTION_CHANGE_TARGET,
+    MACRO_ACTION_RESET_CAMERA,
+    MACRO_ACTION_COUNT,
+};
+static_assert(MACRO_ACTION_COUNT == 12);
+constexpr uint32_t DEFAULT_ACTION_BUTTON_MAP[MACRO_ACTION_COUNT] = {
+    PAD_BUTTON_Y,
+    PAD_BUTTON_X,
+    PAD_BUTTON_A,
+    PAD_BUTTON_B,
+    PAD_BUTTON_B,
+    PAD_BUTTON_L1,
+    PAD_BUTTON_R1,
+    PAD_BUTTON_L2,
+    PAD_BUTTON_R2,
+    PAD_BUTTON_SELECT,
+    PAD_BUTTON_L3,
+    PAD_BUTTON_R3,
+};
 constexpr int DANTE_STYLE_RG = 3;
 constexpr size_t PAD_PRESS_L1 = 8;
 constexpr size_t PAD_PRESS_L2 = 9;
@@ -51,6 +94,7 @@ constexpr size_t PAD_PRESS_R2 = 11;
 constexpr size_t PAD_PRESS_SELECT = 12;
 constexpr size_t PAD_PRESS_L3 = 13;
 constexpr size_t PAD_PRESS_R3 = 14;
+constexpr uint32_t MACRO_CHANGE_TARGET_LATCH_TICKS = 4;
 constexpr uint32_t DEFAULT_RELOAD_VKEY = VK_F9;
 constexpr uint32_t DEFAULT_RESTART_VKEY = VK_F10;
 constexpr uint32_t DEFAULT_STOP_VKEY = VK_F11;
@@ -76,26 +120,48 @@ constexpr const char* CUSTOM_PLAYBACK_LABEL = "Custom";
 
 struct ParsedMacroInput {
     uint32_t buttons = 0;
+    uint32_t global_buttons = 0;
     bool move_up = false;
     bool move_down = false;
     bool move_left = false;
     bool move_right = false;
+    bool walk_up = false;
+    bool walk_down = false;
+    bool walk_left = false;
+    bool walk_right = false;
+    bool camera_up = false;
+    bool camera_down = false;
+    bool camera_left = false;
+    bool camera_right = false;
     bool exceed = false;
+    bool l2_exceed_compat = false;
     bool screen_pause = false;
     bool screen_resume = false;
     bool screen_pause_toggle = false;
+    bool change_target = false;
 };
 
 struct HeldMacroInput {
     uint32_t buttons = 0;
+    uint32_t global_buttons = 0;
     bool move_up = false;
     bool move_down = false;
     bool move_left = false;
     bool move_right = false;
+    bool walk_up = false;
+    bool walk_down = false;
+    bool walk_left = false;
+    bool walk_right = false;
+    bool camera_up = false;
+    bool camera_down = false;
+    bool camera_left = false;
+    bool camera_right = false;
     bool exceed = false;
+    bool l2_exceed_compat = false;
     bool screen_pause = false;
     bool screen_resume = false;
     bool screen_pause_toggle = false;
+    bool change_target = false;
 };
 
 struct BattleEnemySnapshot {
@@ -217,6 +283,12 @@ bool restore_resources_snapshot = false;
 bool keyboard_macro_suspended_for_transition = false;
 cPeripheral* last_player_peripheral = nullptr;
 uint32_t last_player_index = 0;
+uint32_t last_global_routed_buttons[4] = {};
+bool last_global_right_analog[4] = {};
+bool last_change_target_action[4] = {};
+std::string known_macro_file_time_path{};
+uint64_t known_macro_file_write_time = 0;
+bool last_game_pause_state = false;
 
 void update_config_hotkey_vkeys(const std::vector<std::unique_ptr<utility::Hotkey>>& hotkeys);
 std::string trim_copy(const std::string& value);
@@ -235,6 +307,51 @@ sMediator* get_s_mediator_safe();
 uPlayer* get_local_player_safe();
 uCameraCtrl* get_local_camera_safe();
 sWorkRate* get_work_rate_safe();
+sDevil4Pad* get_global_pad_safe();
+
+uint64_t file_time_to_u64(const FILETIME& file_time) {
+    ULARGE_INTEGER value{};
+    value.LowPart = file_time.dwLowDateTime;
+    value.HighPart = file_time.dwHighDateTime;
+    return value.QuadPart;
+}
+
+bool get_file_write_time(const std::string& path, uint64_t& write_time) {
+    write_time = 0;
+    if (path.empty()) {
+        return false;
+    }
+
+    WIN32_FILE_ATTRIBUTE_DATA data{};
+    const auto wide_path = utility::widen(path);
+    if (!GetFileAttributesExW(wide_path.c_str(), GetFileExInfoStandard, &data)) {
+        return false;
+    }
+
+    write_time = file_time_to_u64(data.ftLastWriteTime);
+    return write_time != 0;
+}
+
+void remember_macro_file_write_time(const std::string& path) {
+    uint64_t write_time = 0;
+    if (!get_file_write_time(path, write_time)) {
+        known_macro_file_time_path.clear();
+        known_macro_file_write_time = 0;
+        return;
+    }
+
+    known_macro_file_time_path = path;
+    known_macro_file_write_time = write_time;
+}
+
+bool is_game_paused_safe() {
+    __try {
+        return devil4_sdk::is_paused();
+    }
+    __except (GetExceptionCode() == EXCEPTION_ACCESS_VIOLATION ? EXCEPTION_EXECUTE_HANDLER : EXCEPTION_CONTINUE_SEARCH) {
+        return true;
+    }
+}
 
 bool is_game_window_foreground() {
     auto* window = g_framework ? g_framework->get_window_handle() : nullptr;
@@ -315,6 +432,16 @@ sKeyboard* get_keyboard_safe() {
     }
 }
 
+sDevil4Pad* get_global_pad_safe() {
+    __try {
+        auto** pad_ptr = reinterpret_cast<sDevil4Pad**>(S_DEVIL4_PAD_PTR);
+        return pad_ptr ? *pad_ptr : nullptr;
+    }
+    __except (GetExceptionCode() == EXCEPTION_ACCESS_VIOLATION ? EXCEPTION_EXECUTE_HANDLER : EXCEPTION_CONTINUE_SEARCH) {
+        return nullptr;
+    }
+}
+
 bool read_saved_key_binding(uintptr_t offset, uint32_t& key) {
     key = 0;
 
@@ -369,11 +496,88 @@ bool clear_peripheral_output(cPeripheral* peripheral, uint32_t player_index) {
     }
 }
 
+void set_global_pad_press(kPressInfo& press, uint32_t buttons) {
+    if ((buttons & PAD_BUTTON_L1) != 0) {
+        press.L1 = std::max(press.L1, 1.0f);
+    }
+    if ((buttons & PAD_BUTTON_L2) != 0) {
+        press.L2 = std::max(press.L2, 1.0f);
+    }
+    if ((buttons & PAD_BUTTON_R1) != 0) {
+        press.R1 = std::max(press.R1, 1.0f);
+    }
+    if ((buttons & PAD_BUTTON_R2) != 0) {
+        press.R2 = std::max(press.R2, 1.0f);
+    }
+    if ((buttons & PAD_BUTTON_SELECT) != 0) {
+        press.Select = std::max(press.Select, 1.0f);
+    }
+    if ((buttons & PAD_BUTTON_L3) != 0) {
+        press.L3 = std::max(press.L3, 1.0f);
+    }
+    if ((buttons & PAD_BUTTON_R3) != 0) {
+        press.R3 = std::max(press.R3, 1.0f);
+    }
+}
+
+void clear_global_macro_route(uint32_t player_index) {
+    if (player_index >= 4) {
+        player_index = 0;
+    }
+
+    const uint32_t release_buttons = last_global_routed_buttons[player_index];
+    const bool release_right_analog = last_global_right_analog[player_index];
+    auto* pad = get_global_pad_safe();
+    if (pad) {
+        __try {
+            auto& pad_info = pad->mPadInfo[0];
+            pad_info.mBtn.on &= ~release_buttons;
+            pad_info.mBtn.trg &= ~release_buttons;
+            pad_info.mBtn.rel |= release_buttons;
+
+            if ((release_buttons & PAD_BUTTON_L3) != 0) {
+                pad_info.mPress.L3 = 0.0f;
+            }
+            if ((release_buttons & PAD_BUTTON_R3) != 0) {
+                pad_info.mPress.R3 = 0.0f;
+            }
+            if ((release_buttons & PAD_BUTTON_L1) != 0) {
+                pad_info.mPress.L1 = 0.0f;
+            }
+            if ((release_buttons & PAD_BUTTON_L2) != 0) {
+                pad_info.mPress.L2 = 0.0f;
+            }
+            if ((release_buttons & PAD_BUTTON_R1) != 0) {
+                pad_info.mPress.R1 = 0.0f;
+            }
+            if ((release_buttons & PAD_BUTTON_R2) != 0) {
+                pad_info.mPress.R2 = 0.0f;
+            }
+            if ((release_buttons & PAD_BUTTON_SELECT) != 0) {
+                pad_info.mPress.Select = 0.0f;
+            }
+            if (release_right_analog) {
+                pad_info.mAnlg[1].x = 0.0f;
+                pad_info.mAnlg[1].y = 0.0f;
+            }
+        }
+        __except (GetExceptionCode() == EXCEPTION_ACCESS_VIOLATION ? EXCEPTION_EXECUTE_HANDLER : EXCEPTION_CONTINUE_SEARCH) {
+        }
+    }
+
+    last_global_routed_buttons[player_index] = 0;
+    last_global_right_analog[player_index] = false;
+}
+
 bool clear_last_peripheral_output() {
     if (!clear_peripheral_output(last_player_peripheral, last_player_index)) {
         return false;
     }
 
+    clear_global_macro_route(last_player_index);
+    if (last_player_index < 4) {
+        last_change_target_action[last_player_index] = false;
+    }
     std::fill_n(KeyboardMacro::last_buttons, 4, 0);
     return true;
 }
@@ -394,6 +598,7 @@ void suspend_keyboard_macro_runtime_for_transition() {
     KeyboardMacro::input_active = false;
     KeyboardMacro::macro_exceed_active = false;
     KeyboardMacro::macro_exceed_latch_ticks = 0;
+    KeyboardMacro::macro_change_target_latch_ticks = 0;
     position_snapshot_load_ticks = 0;
     snapshot_play_pending_ticks = 0;
     snapshot_play_pending_clip_index = INVALID_CLIP_INDEX;
@@ -412,6 +617,11 @@ void update_macro_exceed_active_from_latch() {
 void queue_macro_exceed_request() {
     KeyboardMacro::macro_exceed_latch_ticks = std::max(KeyboardMacro::macro_exceed_latch_ticks, MACRO_EXCEED_LATCH_TICKS);
     update_macro_exceed_active_from_latch();
+}
+
+void queue_macro_change_target_request() {
+    KeyboardMacro::macro_change_target_latch_ticks =
+        std::max(KeyboardMacro::macro_change_target_latch_ticks, MACRO_CHANGE_TARGET_LATCH_TICKS);
 }
 
 void ensure_keyboard_macro_hotkeys(std::vector<std::unique_ptr<utility::Hotkey>>& hotkeys) {
@@ -899,35 +1109,93 @@ bool parse_button_name(const std::string& token, uint32_t& button) {
     }
 
     static const std::pair<const char*, uint32_t> buttons[] = {
-        {"SELECT", 0x0001},
-        {"L3", 0x0002},
-        {"R3", 0x0004},
-        {"START", 0x0008},
-        {"PAUSE", 0x0008},
-        {"PAUSE_MENU", 0x0008},
-        {"PAVSE", 0x0008},
-        {"PAVSE_MENU", 0x0008},
-        {"MENU", 0x0008},
-        {"START_MENU", 0x0008},
-        {"OPTIONS", 0x0008},
-        {"ESC", 0x0008},
-        {"ESCAPE", 0x0008},
-        {"DPAD_UP", 0x0010},
-        {"UP", 0x0010},
-        {"DPAD_RIGHT", 0x0020},
-        {"RIGHT", 0x0020},
-        {"DPAD_DOWN", 0x0040},
-        {"DOWN", 0x0040},
-        {"DPAD_LEFT", 0x0080},
-        {"LEFT", 0x0080},
-        {"L1", 0x0100},
-        {"R1", 0x0200},
-        {"L2", 0x0400},
-        {"R2", 0x0800},
-        {"Y", 0x1000},
-        {"B", 0x2000},
-        {"A", 0x4000},
-        {"X", 0x8000},
+        {"SELECT", PAD_BUTTON_SELECT},
+        {"SELECT_BUTTON", PAD_BUTTON_SELECT},
+        {"BACK", PAD_BUTTON_SELECT},
+        {"BACK_BUTTON", PAD_BUTTON_SELECT},
+        {"VIEW", PAD_BUTTON_SELECT},
+        {"SHARE", PAD_BUTTON_SELECT},
+        {"SHARE_BUTTON", PAD_BUTTON_SELECT},
+
+        {"LS", PAD_BUTTON_L3},
+        {"L3", PAD_BUTTON_L3},
+        {"LEFT_STICK_CLICK", PAD_BUTTON_L3},
+        {"LEFTSTICK_CLICK", PAD_BUTTON_L3},
+
+        {"RS", PAD_BUTTON_R3},
+        {"R3", PAD_BUTTON_R3},
+        {"RIGHT_STICK_CLICK", PAD_BUTTON_R3},
+        {"RIGHTSTICK_CLICK", PAD_BUTTON_R3},
+
+        {"START", PAD_BUTTON_START},
+        {"START_BUTTON", PAD_BUTTON_START},
+        {"PAUSE", PAD_BUTTON_START},
+        {"PAUSE_MENU", PAD_BUTTON_START},
+        {"PAVSE", PAD_BUTTON_START},
+        {"PAVSE_MENU", PAD_BUTTON_START},
+        {"MENU", PAD_BUTTON_START},
+        {"START_MENU", PAD_BUTTON_START},
+        {"OPTIONS", PAD_BUTTON_START},
+        {"OPTIONS_BUTTON", PAD_BUTTON_START},
+        {"ESC", PAD_BUTTON_START},
+        {"ESCAPE", PAD_BUTTON_START},
+
+        {"DPAD_UP", PAD_BUTTON_DPAD_UP},
+        {"D_PAD_UP", PAD_BUTTON_DPAD_UP},
+        {"UP", PAD_BUTTON_DPAD_UP},
+        {"STYLE_TRICKSTER", PAD_BUTTON_DPAD_UP},
+        {"STYLE_TS", PAD_BUTTON_DPAD_UP},
+        {"TRICKSTER", PAD_BUTTON_DPAD_UP},
+        {"DPAD_RIGHT", PAD_BUTTON_DPAD_RIGHT},
+        {"D_PAD_RIGHT", PAD_BUTTON_DPAD_RIGHT},
+        {"RIGHT", PAD_BUTTON_DPAD_RIGHT},
+        {"STYLE_SWORDMASTER", PAD_BUTTON_DPAD_RIGHT},
+        {"STYLE_SM", PAD_BUTTON_DPAD_RIGHT},
+        {"SWORDMASTER", PAD_BUTTON_DPAD_RIGHT},
+        {"SWORD_MASTER", PAD_BUTTON_DPAD_RIGHT},
+        {"DPAD_DOWN", PAD_BUTTON_DPAD_DOWN},
+        {"D_PAD_DOWN", PAD_BUTTON_DPAD_DOWN},
+        {"DOWN", PAD_BUTTON_DPAD_DOWN},
+        {"STYLE_ROYALGUARD", PAD_BUTTON_DPAD_DOWN},
+        {"STYLE_RG", PAD_BUTTON_DPAD_DOWN},
+        {"ROYALGUARD", PAD_BUTTON_DPAD_DOWN},
+        {"ROYAL_GUARD", PAD_BUTTON_DPAD_DOWN},
+        {"DPAD_LEFT", PAD_BUTTON_DPAD_LEFT},
+        {"D_PAD_LEFT", PAD_BUTTON_DPAD_LEFT},
+        {"LEFT", PAD_BUTTON_DPAD_LEFT},
+        {"STYLE_GUNSLINGER", PAD_BUTTON_DPAD_LEFT},
+        {"STYLE_GS", PAD_BUTTON_DPAD_LEFT},
+        {"GUNSLINGER", PAD_BUTTON_DPAD_LEFT},
+        {"GUN_SLINGER", PAD_BUTTON_DPAD_LEFT},
+
+        {"L1", PAD_BUTTON_L1},
+        {"LB", PAD_BUTTON_L1},
+        {"LEFT_BUMPER", PAD_BUTTON_L1},
+        {"R1", PAD_BUTTON_R1},
+        {"RB", PAD_BUTTON_R1},
+        {"RIGHT_BUMPER", PAD_BUTTON_R1},
+        {"L2", PAD_BUTTON_L2},
+        {"LT", PAD_BUTTON_L2},
+        {"LEFT_TRIGGER", PAD_BUTTON_L2},
+        {"R2", PAD_BUTTON_R2},
+        {"RT", PAD_BUTTON_R2},
+        {"RIGHT_TRIGGER", PAD_BUTTON_R2},
+
+        {"Y", PAD_BUTTON_Y},
+        {"Y_BUTTON", PAD_BUTTON_Y},
+        {"TRIANGLE", PAD_BUTTON_Y},
+        {"TRI", PAD_BUTTON_Y},
+        {"B", PAD_BUTTON_B},
+        {"B_BUTTON", PAD_BUTTON_B},
+        {"CIRCLE", PAD_BUTTON_B},
+        {"O", PAD_BUTTON_B},
+        {"A", PAD_BUTTON_A},
+        {"A_BUTTON", PAD_BUTTON_A},
+        {"CROSS", PAD_BUTTON_A},
+        {"X", PAD_BUTTON_X},
+        {"X_BUTTON", PAD_BUTTON_X},
+        {"SQUARE", PAD_BUTTON_X},
+        {"SQ", PAD_BUTTON_X},
     };
 
     for (const auto& entry : buttons) {
@@ -938,6 +1206,130 @@ bool parse_button_name(const std::string& token, uint32_t& button) {
     }
 
     return false;
+}
+
+bool parse_action_name(const std::string& token, uint32_t& action_index) {
+    const auto normalized = normalize_button_token(token);
+
+    static const std::pair<const char*, uint32_t> actions[] = {
+        {"MELEE", MACRO_ACTION_MELEE},
+        {"MELEE_ATTACK", MACRO_ACTION_MELEE},
+        {"SWORD_ATTACK", MACRO_ACTION_MELEE},
+        {"ATTACK", MACRO_ACTION_MELEE},
+        {"GUN", MACRO_ACTION_GUN},
+        {"GUN_ATTACK", MACRO_ACTION_GUN},
+        {"SHOOT", MACRO_ACTION_GUN},
+        {"FIRE", MACRO_ACTION_GUN},
+        {"JUMP", MACRO_ACTION_JUMP},
+        {"BRINGER", MACRO_ACTION_BRINGER},
+        {"DEVIL_BRINGER", MACRO_ACTION_BRINGER},
+        {"STYLE_ACTION", MACRO_ACTION_STYLE_ACTION},
+        {"STYLE_BUTTON", MACRO_ACTION_STYLE_ACTION},
+        {"DEVIL_TRIGGER", MACRO_ACTION_DEVIL_TRIGGER},
+        {"DT", MACRO_ACTION_DEVIL_TRIGGER},
+        {"LOCK_ON", MACRO_ACTION_LOCK_ON},
+        {"LOCKON", MACRO_ACTION_LOCK_ON},
+        {"LOCK", MACRO_ACTION_LOCK_ON},
+        {"TARGET_LOCK", MACRO_ACTION_LOCK_ON},
+        {"CHANGE_GUN", MACRO_ACTION_CHANGE_GUN},
+        {"GUN_CHANGE", MACRO_ACTION_CHANGE_GUN},
+        {"DANTE_CHANGE_GUN", MACRO_ACTION_CHANGE_GUN},
+        {"CHANGE_SWORD", MACRO_ACTION_CHANGE_SWORD},
+        {"SWORD_CHANGE", MACRO_ACTION_CHANGE_SWORD},
+        {"DANTE_CHANGE_SWORD", MACRO_ACTION_CHANGE_SWORD},
+        {"TAUNT", MACRO_ACTION_TAUNT},
+        {"CHANGE_TARGET", MACRO_ACTION_CHANGE_TARGET},
+        {"TARGET_CHANGE", MACRO_ACTION_CHANGE_TARGET},
+        {"CYCLE_TARGET", MACRO_ACTION_CHANGE_TARGET},
+        {"NEXT_TARGET", MACRO_ACTION_CHANGE_TARGET},
+        {"RESET_CAMERA", MACRO_ACTION_RESET_CAMERA},
+        {"CAMERA_RESET", MACRO_ACTION_RESET_CAMERA},
+        {"CENTER_CAMERA", MACRO_ACTION_RESET_CAMERA},
+    };
+
+    for (const auto& entry : actions) {
+        if (normalized == entry.first) {
+            action_index = entry.second;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool is_l2_button_token(const std::string& normalized) {
+    return normalized == "L2" || normalized == "LT" || normalized == "LEFT_TRIGGER";
+}
+
+struct MacroButtonChoice {
+    const char* label;
+    uint32_t button;
+};
+
+const MacroButtonChoice* macro_button_choices(size_t& count) {
+    static const MacroButtonChoice choices[] = {
+        {"Y / TRIANGLE", PAD_BUTTON_Y},
+        {"X / SQUARE", PAD_BUTTON_X},
+        {"A / CROSS", PAD_BUTTON_A},
+        {"B / CIRCLE", PAD_BUTTON_B},
+        {"LB / L1", PAD_BUTTON_L1},
+        {"RB / R1", PAD_BUTTON_R1},
+        {"LT / L2", PAD_BUTTON_L2},
+        {"RT / R2", PAD_BUTTON_R2},
+        {"LS / L3", PAD_BUTTON_L3},
+        {"RS / R3", PAD_BUTTON_R3},
+        {"START / OPTIONS", PAD_BUTTON_START},
+        {"BACK / SHARE", PAD_BUTTON_SELECT},
+    };
+    count = sizeof(choices) / sizeof(choices[0]);
+    return choices;
+}
+
+const char* macro_button_label(uint32_t button) {
+    size_t count = 0;
+    const auto* choices = macro_button_choices(count);
+    for (size_t i = 0; i < count; ++i) {
+        if (choices[i].button == button) {
+            return choices[i].label;
+        }
+    }
+    return "Unknown";
+}
+
+uint32_t sanitize_macro_button(uint32_t button, uint32_t fallback) {
+    size_t count = 0;
+    const auto* choices = macro_button_choices(count);
+    for (size_t i = 0; i < count; ++i) {
+        if (choices[i].button == button) {
+            return button;
+        }
+    }
+    return fallback;
+}
+
+struct MacroActionChoice {
+    const char* config_key;
+    const char* label;
+    uint32_t default_button;
+};
+
+const MacroActionChoice* macro_action_choices(size_t& count) {
+    static const MacroActionChoice choices[MACRO_ACTION_COUNT] = {
+        {"keyboard_macro_action_melee", "MELEE", PAD_BUTTON_Y},
+        {"keyboard_macro_action_gun", "GUN", PAD_BUTTON_X},
+        {"keyboard_macro_action_jump", "JUMP", PAD_BUTTON_A},
+        {"keyboard_macro_action_bringer", "BRINGER", PAD_BUTTON_B},
+        {"keyboard_macro_action_style_action", "STYLE_ACTION", PAD_BUTTON_B},
+        {"keyboard_macro_action_devil_trigger", "DEVIL_TRIGGER", PAD_BUTTON_L1},
+        {"keyboard_macro_action_lock_on", "LOCK_ON", PAD_BUTTON_R1},
+        {"keyboard_macro_action_change_gun", "CHANGE_GUN", PAD_BUTTON_L2},
+        {"keyboard_macro_action_change_sword", "CHANGE_SWORD", PAD_BUTTON_R2},
+        {"keyboard_macro_action_taunt", "TAUNT", PAD_BUTTON_SELECT},
+        {"keyboard_macro_action_change_target", "CHANGE_TARGET", PAD_BUTTON_L3},
+        {"keyboard_macro_action_reset_camera", "RESET_CAMERA", PAD_BUTTON_R3},
+    };
+    count = sizeof(choices) / sizeof(choices[0]);
+    return choices;
 }
 
 bool parse_style_name(const std::string& token, int& style) {
@@ -1051,6 +1443,14 @@ bool parse_left_analog_name(const std::string& token, int& x, int& y) {
         {"FORWARD", {0, ANALOG_MAX}},
         {"LSTICK_UP", {0, ANALOG_MAX}},
         {"LS_UP", {0, ANALOG_MAX}},
+        {"WALK_MW", {0, ANALOG_WALK}},
+        {"WALK_W", {0, ANALOG_WALK}},
+        {"WALK_UP", {0, ANALOG_WALK}},
+        {"WALK_FORWARD", {0, ANALOG_WALK}},
+        {"SLOW_MW", {0, ANALOG_WALK}},
+        {"SLOW_W", {0, ANALOG_WALK}},
+        {"SLOW_UP", {0, ANALOG_WALK}},
+        {"SLOW_FORWARD", {0, ANALOG_WALK}},
         {"S", {0, ANALOG_MIN}},
         {"MS", {0, ANALOG_MIN}},
         {"MOVE_S", {0, ANALOG_MIN}},
@@ -1060,33 +1460,136 @@ bool parse_left_analog_name(const std::string& token, int& x, int& y) {
         {"BACKWARD", {0, ANALOG_MIN}},
         {"LSTICK_DOWN", {0, ANALOG_MIN}},
         {"LS_DOWN", {0, ANALOG_MIN}},
+        {"WALK_MS", {0, -ANALOG_WALK}},
+        {"WALK_S", {0, -ANALOG_WALK}},
+        {"WALK_DOWN", {0, -ANALOG_WALK}},
+        {"WALK_BACK", {0, -ANALOG_WALK}},
+        {"WALK_BACKWARD", {0, -ANALOG_WALK}},
+        {"SLOW_MS", {0, -ANALOG_WALK}},
+        {"SLOW_S", {0, -ANALOG_WALK}},
+        {"SLOW_DOWN", {0, -ANALOG_WALK}},
+        {"SLOW_BACK", {0, -ANALOG_WALK}},
+        {"SLOW_BACKWARD", {0, -ANALOG_WALK}},
         {"D", {ANALOG_MAX, 0}},
         {"MD", {ANALOG_MAX, 0}},
         {"MOVE_D", {ANALOG_MAX, 0}},
         {"MOVE_RIGHT", {ANALOG_MAX, 0}},
         {"LSTICK_RIGHT", {ANALOG_MAX, 0}},
         {"LS_RIGHT", {ANALOG_MAX, 0}},
+        {"WALK_MD", {ANALOG_WALK, 0}},
+        {"WALK_D", {ANALOG_WALK, 0}},
+        {"WALK_RIGHT", {ANALOG_WALK, 0}},
+        {"SLOW_MD", {ANALOG_WALK, 0}},
+        {"SLOW_D", {ANALOG_WALK, 0}},
+        {"SLOW_RIGHT", {ANALOG_WALK, 0}},
         {"MA", {ANALOG_MIN, 0}},
         {"MOVE_A", {ANALOG_MIN, 0}},
         {"MOVE_LEFT", {ANALOG_MIN, 0}},
         {"LSTICK_LEFT", {ANALOG_MIN, 0}},
         {"LS_LEFT", {ANALOG_MIN, 0}},
+        {"WALK_MA", {-ANALOG_WALK, 0}},
+        {"WALK_A", {-ANALOG_WALK, 0}},
+        {"WALK_LEFT", {-ANALOG_WALK, 0}},
+        {"SLOW_MA", {-ANALOG_WALK, 0}},
+        {"SLOW_A", {-ANALOG_WALK, 0}},
+        {"SLOW_LEFT", {-ANALOG_WALK, 0}},
         {"MW_MD", {ANALOG_MAX, ANALOG_MAX}},
         {"MOVE_UP_RIGHT", {ANALOG_MAX, ANALOG_MAX}},
         {"LSTICK_UP_RIGHT", {ANALOG_MAX, ANALOG_MAX}},
         {"LS_UP_RIGHT", {ANALOG_MAX, ANALOG_MAX}},
+        {"WALK_MW_MD", {ANALOG_WALK, ANALOG_WALK}},
+        {"WALK_UP_RIGHT", {ANALOG_WALK, ANALOG_WALK}},
+        {"SLOW_MW_MD", {ANALOG_WALK, ANALOG_WALK}},
+        {"SLOW_UP_RIGHT", {ANALOG_WALK, ANALOG_WALK}},
         {"MW_MA", {ANALOG_MIN, ANALOG_MAX}},
         {"MOVE_UP_LEFT", {ANALOG_MIN, ANALOG_MAX}},
         {"LSTICK_UP_LEFT", {ANALOG_MIN, ANALOG_MAX}},
         {"LS_UP_LEFT", {ANALOG_MIN, ANALOG_MAX}},
+        {"WALK_MW_MA", {-ANALOG_WALK, ANALOG_WALK}},
+        {"WALK_UP_LEFT", {-ANALOG_WALK, ANALOG_WALK}},
+        {"SLOW_MW_MA", {-ANALOG_WALK, ANALOG_WALK}},
+        {"SLOW_UP_LEFT", {-ANALOG_WALK, ANALOG_WALK}},
         {"MS_MD", {ANALOG_MAX, ANALOG_MIN}},
         {"MOVE_DOWN_RIGHT", {ANALOG_MAX, ANALOG_MIN}},
         {"LSTICK_DOWN_RIGHT", {ANALOG_MAX, ANALOG_MIN}},
         {"LS_DOWN_RIGHT", {ANALOG_MAX, ANALOG_MIN}},
+        {"WALK_MS_MD", {ANALOG_WALK, -ANALOG_WALK}},
+        {"WALK_DOWN_RIGHT", {ANALOG_WALK, -ANALOG_WALK}},
+        {"SLOW_MS_MD", {ANALOG_WALK, -ANALOG_WALK}},
+        {"SLOW_DOWN_RIGHT", {ANALOG_WALK, -ANALOG_WALK}},
         {"MS_MA", {ANALOG_MIN, ANALOG_MIN}},
         {"MOVE_DOWN_LEFT", {ANALOG_MIN, ANALOG_MIN}},
         {"LSTICK_DOWN_LEFT", {ANALOG_MIN, ANALOG_MIN}},
         {"LS_DOWN_LEFT", {ANALOG_MIN, ANALOG_MIN}},
+        {"WALK_MS_MA", {-ANALOG_WALK, -ANALOG_WALK}},
+        {"WALK_DOWN_LEFT", {-ANALOG_WALK, -ANALOG_WALK}},
+        {"SLOW_MS_MA", {-ANALOG_WALK, -ANALOG_WALK}},
+        {"SLOW_DOWN_LEFT", {-ANALOG_WALK, -ANALOG_WALK}},
+    };
+
+    for (const auto& entry : directions) {
+        if (normalized == entry.first) {
+            x = entry.second.first;
+            y = entry.second.second;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool parse_right_analog_name(const std::string& token, int& x, int& y) {
+    const auto normalized = normalize_button_token(token);
+
+    static const std::pair<const char*, std::pair<int, int>> directions[] = {
+        {"TW", {0, ANALOG_MAX}},
+        {"CAM_UP", {0, ANALOG_MAX}},
+        {"CAMERA_UP", {0, ANALOG_MAX}},
+        {"RSTICK_UP", {0, ANALOG_MAX}},
+        {"RS_UP", {0, ANALOG_MAX}},
+        {"RIGHT_STICK_UP", {0, ANALOG_MAX}},
+        {"TS", {0, ANALOG_MIN}},
+        {"CAM_DOWN", {0, ANALOG_MIN}},
+        {"CAMERA_DOWN", {0, ANALOG_MIN}},
+        {"RSTICK_DOWN", {0, ANALOG_MIN}},
+        {"RS_DOWN", {0, ANALOG_MIN}},
+        {"RIGHT_STICK_DOWN", {0, ANALOG_MIN}},
+        {"TD", {ANALOG_MAX, 0}},
+        {"CAM_RIGHT", {ANALOG_MAX, 0}},
+        {"CAMERA_RIGHT", {ANALOG_MAX, 0}},
+        {"RSTICK_RIGHT", {ANALOG_MAX, 0}},
+        {"RS_RIGHT", {ANALOG_MAX, 0}},
+        {"RIGHT_STICK_RIGHT", {ANALOG_MAX, 0}},
+        {"TA", {ANALOG_MIN, 0}},
+        {"CAM_LEFT", {ANALOG_MIN, 0}},
+        {"CAMERA_LEFT", {ANALOG_MIN, 0}},
+        {"RSTICK_LEFT", {ANALOG_MIN, 0}},
+        {"RS_LEFT", {ANALOG_MIN, 0}},
+        {"RIGHT_STICK_LEFT", {ANALOG_MIN, 0}},
+        {"TW_TD", {ANALOG_MAX, ANALOG_MAX}},
+        {"CAM_UP_RIGHT", {ANALOG_MAX, ANALOG_MAX}},
+        {"CAMERA_UP_RIGHT", {ANALOG_MAX, ANALOG_MAX}},
+        {"RS_UP_RIGHT", {ANALOG_MAX, ANALOG_MAX}},
+        {"RSTICK_UP_RIGHT", {ANALOG_MAX, ANALOG_MAX}},
+        {"RIGHT_STICK_UP_RIGHT", {ANALOG_MAX, ANALOG_MAX}},
+        {"TW_TA", {ANALOG_MIN, ANALOG_MAX}},
+        {"CAM_UP_LEFT", {ANALOG_MIN, ANALOG_MAX}},
+        {"CAMERA_UP_LEFT", {ANALOG_MIN, ANALOG_MAX}},
+        {"RS_UP_LEFT", {ANALOG_MIN, ANALOG_MAX}},
+        {"RSTICK_UP_LEFT", {ANALOG_MIN, ANALOG_MAX}},
+        {"RIGHT_STICK_UP_LEFT", {ANALOG_MIN, ANALOG_MAX}},
+        {"TS_TD", {ANALOG_MAX, ANALOG_MIN}},
+        {"CAM_DOWN_RIGHT", {ANALOG_MAX, ANALOG_MIN}},
+        {"CAMERA_DOWN_RIGHT", {ANALOG_MAX, ANALOG_MIN}},
+        {"RS_DOWN_RIGHT", {ANALOG_MAX, ANALOG_MIN}},
+        {"RSTICK_DOWN_RIGHT", {ANALOG_MAX, ANALOG_MIN}},
+        {"RIGHT_STICK_DOWN_RIGHT", {ANALOG_MAX, ANALOG_MIN}},
+        {"TS_TA", {ANALOG_MIN, ANALOG_MIN}},
+        {"CAM_DOWN_LEFT", {ANALOG_MIN, ANALOG_MIN}},
+        {"CAMERA_DOWN_LEFT", {ANALOG_MIN, ANALOG_MIN}},
+        {"RS_DOWN_LEFT", {ANALOG_MIN, ANALOG_MIN}},
+        {"RSTICK_DOWN_LEFT", {ANALOG_MIN, ANALOG_MIN}},
+        {"RIGHT_STICK_DOWN_LEFT", {ANALOG_MIN, ANALOG_MIN}},
     };
 
     for (const auto& entry : directions) {
@@ -1102,53 +1605,121 @@ bool parse_left_analog_name(const std::string& token, int& x, int& y) {
 
 void apply_direction_to_input(ParsedMacroInput& input, int x, int y) {
     if (x < 0) {
-        input.move_left = true;
+        if (std::abs(x) < ANALOG_MAX) {
+            input.walk_left = true;
+        }
+        else {
+            input.move_left = true;
+        }
     }
     else if (x > 0) {
-        input.move_right = true;
+        if (std::abs(x) < ANALOG_MAX) {
+            input.walk_right = true;
+        }
+        else {
+            input.move_right = true;
+        }
     }
 
     if (y < 0) {
-        input.move_down = true;
+        if (std::abs(y) < ANALOG_MAX) {
+            input.walk_down = true;
+        }
+        else {
+            input.move_down = true;
+        }
     }
     else if (y > 0) {
-        input.move_up = true;
+        if (std::abs(y) < ANALOG_MAX) {
+            input.walk_up = true;
+        }
+        else {
+            input.move_up = true;
+        }
+    }
+}
+
+void apply_camera_direction_to_input(ParsedMacroInput& input, int x, int y) {
+    if (x < 0) {
+        input.camera_left = true;
+    }
+    else if (x > 0) {
+        input.camera_right = true;
+    }
+
+    if (y < 0) {
+        input.camera_down = true;
+    }
+    else if (y > 0) {
+        input.camera_up = true;
     }
 }
 
 KeyboardMacroFrame frame_from_parts(
     uint32_t buttons,
+    uint32_t global_buttons,
     bool move_up,
     bool move_down,
     bool move_left,
     bool move_right,
+    bool walk_up,
+    bool walk_down,
+    bool walk_left,
+    bool walk_right,
+    bool camera_up,
+    bool camera_down,
+    bool camera_left,
+    bool camera_right,
     bool exceed,
+    bool l2_exceed_compat,
     bool screen_pause,
     bool screen_resume,
-    bool screen_pause_toggle) {
+    bool screen_pause_toggle,
+    bool change_target) {
     KeyboardMacroFrame frame{};
     frame.buttons = buttons;
-    frame.left_x = clamp_analog((move_right ? ANALOG_MAX : 0) + (move_left ? ANALOG_MIN : 0));
-    frame.left_y = clamp_analog((move_up ? ANALOG_MAX : 0) + (move_down ? ANALOG_MIN : 0));
-    frame.has_left_analog = move_up || move_down || move_left || move_right;
+    frame.global_buttons = global_buttons;
+    frame.left_x = clamp_analog(
+        (move_right ? ANALOG_MAX : 0) + (move_left ? ANALOG_MIN : 0) +
+        (walk_right ? ANALOG_WALK : 0) + (walk_left ? -ANALOG_WALK : 0));
+    frame.left_y = clamp_analog(
+        (move_up ? ANALOG_MAX : 0) + (move_down ? ANALOG_MIN : 0) +
+        (walk_up ? ANALOG_WALK : 0) + (walk_down ? -ANALOG_WALK : 0));
+    frame.has_left_analog = move_up || move_down || move_left || move_right || walk_up || walk_down || walk_left || walk_right;
+    frame.right_x = clamp_analog((camera_right ? ANALOG_MAX : 0) + (camera_left ? ANALOG_MIN : 0));
+    frame.right_y = clamp_analog((camera_up ? ANALOG_MAX : 0) + (camera_down ? ANALOG_MIN : 0));
+    frame.has_right_analog = camera_up || camera_down || camera_left || camera_right;
     frame.exceed = exceed;
+    frame.l2_exceed_compat = l2_exceed_compat;
     frame.screen_pause = screen_pause;
     frame.screen_resume = screen_resume;
     frame.screen_pause_toggle = screen_pause_toggle;
+    frame.change_target = change_target;
     return frame;
 }
 
 KeyboardMacroFrame frame_from_input(const ParsedMacroInput& input) {
     return frame_from_parts(
         input.buttons,
+        input.global_buttons,
         input.move_up,
         input.move_down,
         input.move_left,
         input.move_right,
+        input.walk_up,
+        input.walk_down,
+        input.walk_left,
+        input.walk_right,
+        input.camera_up,
+        input.camera_down,
+        input.camera_left,
+        input.camera_right,
         input.exceed,
+        input.l2_exceed_compat,
         input.screen_pause,
         input.screen_resume,
-        input.screen_pause_toggle);
+        input.screen_pause_toggle,
+        input.change_target);
 }
 
 KeyboardMacroFrame frame_from_forced_style(int style) {
@@ -1158,17 +1729,42 @@ KeyboardMacroFrame frame_from_forced_style(int style) {
     return frame;
 }
 
+KeyboardMacroFrame frame_from_character_switch() {
+    KeyboardMacroFrame frame{};
+    frame.character_switch = true;
+    return frame;
+}
+
+KeyboardMacroFrame frame_from_one_hit_kill(bool toggle, bool value) {
+    KeyboardMacroFrame frame{};
+    frame.one_hit_kill_toggle = toggle;
+    frame.one_hit_kill_set = !toggle;
+    frame.one_hit_kill_value = value;
+    return frame;
+}
+
 KeyboardMacroFrame frame_from_held(const HeldMacroInput& input) {
     return frame_from_parts(
         input.buttons,
+        input.global_buttons,
         input.move_up,
         input.move_down,
         input.move_left,
         input.move_right,
+        input.walk_up,
+        input.walk_down,
+        input.walk_left,
+        input.walk_right,
+        input.camera_up,
+        input.camera_down,
+        input.camera_left,
+        input.camera_right,
         input.exceed,
+        input.l2_exceed_compat,
         input.screen_pause,
         input.screen_resume,
-        input.screen_pause_toggle);
+        input.screen_pause_toggle,
+        input.change_target);
 }
 
 KeyboardMacroFrame frame_from_wait_condition(
@@ -1203,8 +1799,8 @@ bool parse_macro_input(std::string expression, ParsedMacroInput& input) {
             continue;
         }
 
-        if (normalized == "EXCEED" || normalized == "EX" || normalized == "REV" ||
-            normalized == "MAX_ACT" || normalized == "MAXACT") {
+        if (normalized == "EXCEED" || normalized == "NERO_EXCEED" || normalized == "EXCEED_INPUT" ||
+            normalized == "EX" || normalized == "REV" || normalized == "MAX_ACT" || normalized == "MAXACT") {
             input.exceed = true;
             found_token = true;
             continue;
@@ -1230,8 +1826,31 @@ bool parse_macro_input(std::string expression, ParsedMacroInput& input) {
             continue;
         }
 
+        uint32_t action_index = 0;
+        if (parse_action_name(token, action_index)) {
+            if (action_index < MACRO_ACTION_COUNT) {
+                const uint32_t button = KeyboardMacro::action_button_map[action_index];
+                input.buttons |= button;
+                if (action_index == MACRO_ACTION_RESET_CAMERA) {
+                    input.global_buttons |= button;
+                }
+                if (action_index == MACRO_ACTION_CHANGE_TARGET) {
+                    input.change_target = true;
+                }
+                found_token = true;
+                continue;
+            }
+            return false;
+        }
+
         int direction_x = 0;
         int direction_y = 0;
+        if (parse_right_analog_name(token, direction_x, direction_y)) {
+            apply_camera_direction_to_input(input, direction_x, direction_y);
+            found_token = true;
+            continue;
+        }
+
         if (parse_left_analog_name(token, direction_x, direction_y)) {
             apply_direction_to_input(input, direction_x, direction_y);
             found_token = true;
@@ -1243,6 +1862,12 @@ bool parse_macro_input(std::string expression, ParsedMacroInput& input) {
             return false;
         }
         input.buttons |= button;
+        if ((button & PAD_BUTTON_GLOBAL_ROUTE_MASK) != 0) {
+            input.global_buttons |= button;
+        }
+        if (is_l2_button_token(normalized)) {
+            input.l2_exceed_compat = true;
+        }
         found_token = true;
     }
 
@@ -1261,18 +1886,30 @@ bool parse_playback_command(std::string expression, KeyboardMacroFrame& frame) {
 
 void hold_input(HeldMacroInput& held, const ParsedMacroInput& input) {
     held.buttons |= input.buttons;
+    held.global_buttons |= input.global_buttons;
     held.move_up |= input.move_up;
     held.move_down |= input.move_down;
     held.move_left |= input.move_left;
     held.move_right |= input.move_right;
+    held.walk_up |= input.walk_up;
+    held.walk_down |= input.walk_down;
+    held.walk_left |= input.walk_left;
+    held.walk_right |= input.walk_right;
+    held.camera_up |= input.camera_up;
+    held.camera_down |= input.camera_down;
+    held.camera_left |= input.camera_left;
+    held.camera_right |= input.camera_right;
     held.exceed |= input.exceed;
+    held.l2_exceed_compat |= input.l2_exceed_compat;
     held.screen_pause |= input.screen_pause;
     held.screen_resume |= input.screen_resume;
     held.screen_pause_toggle |= input.screen_pause_toggle;
+    held.change_target |= input.change_target;
 }
 
 void release_input(HeldMacroInput& held, const ParsedMacroInput& input) {
     held.buttons &= ~input.buttons;
+    held.global_buttons &= ~input.global_buttons;
     if (input.move_up) {
         held.move_up = false;
     }
@@ -1285,8 +1922,35 @@ void release_input(HeldMacroInput& held, const ParsedMacroInput& input) {
     if (input.move_right) {
         held.move_right = false;
     }
+    if (input.walk_up) {
+        held.walk_up = false;
+    }
+    if (input.walk_down) {
+        held.walk_down = false;
+    }
+    if (input.walk_left) {
+        held.walk_left = false;
+    }
+    if (input.walk_right) {
+        held.walk_right = false;
+    }
+    if (input.camera_up) {
+        held.camera_up = false;
+    }
+    if (input.camera_down) {
+        held.camera_down = false;
+    }
+    if (input.camera_left) {
+        held.camera_left = false;
+    }
+    if (input.camera_right) {
+        held.camera_right = false;
+    }
     if (input.exceed) {
         held.exceed = false;
+    }
+    if (input.l2_exceed_compat) {
+        held.l2_exceed_compat = false;
     }
     if (input.screen_pause) {
         held.screen_pause = false;
@@ -1296,6 +1960,9 @@ void release_input(HeldMacroInput& held, const ParsedMacroInput& input) {
     }
     if (input.screen_pause_toggle) {
         held.screen_pause_toggle = false;
+    }
+    if (input.change_target) {
+        held.change_target = false;
     }
 }
 
@@ -1526,6 +2193,55 @@ void apply_button_press_values(cPeripheral* peripheral, uint32_t buttons) {
     set_pad_press(peripheral, buttons, PAD_BUTTON_SELECT, PAD_PRESS_SELECT);
     set_pad_press(peripheral, buttons, PAD_BUTTON_L3, PAD_PRESS_L3);
     set_pad_press(peripheral, buttons, PAD_BUTTON_R3, PAD_PRESS_R3);
+}
+
+void apply_global_pad_route_for_macro(
+    const KeyboardMacroFrame& frame,
+    uint32_t routed_buttons,
+    uint32_t previous_routed_buttons,
+    uint32_t player_index) {
+    if (player_index >= 4) {
+        player_index = 0;
+    }
+
+    auto* pad = get_global_pad_safe();
+    if (!pad) {
+        last_global_routed_buttons[player_index] = routed_buttons;
+        last_global_right_analog[player_index] = frame.has_right_analog;
+        return;
+    }
+
+    __try {
+        auto& pad_info = pad->mPadInfo[0];
+        const uint32_t pressed_buttons = routed_buttons & ~previous_routed_buttons;
+        const uint32_t released_buttons = previous_routed_buttons & ~routed_buttons;
+
+        pad_info.mBtn.on &= ~previous_routed_buttons;
+        pad_info.mBtn.on |= routed_buttons;
+        pad_info.mBtn.trg |= pressed_buttons;
+        pad_info.mBtn.rel |= released_buttons;
+        set_global_pad_press(pad_info.mPress, routed_buttons);
+
+        if (frame.has_right_analog) {
+            pad_info.mAnlg[1].x = std::clamp(
+                pad_info.mAnlg[1].x + (static_cast<float>(frame.right_x) / static_cast<float>(ANALOG_MAX)),
+                -1.0f,
+                1.0f);
+            pad_info.mAnlg[1].y = std::clamp(
+                pad_info.mAnlg[1].y + (static_cast<float>(frame.right_y) / static_cast<float>(ANALOG_MAX)),
+                -1.0f,
+                1.0f);
+        }
+        else if (last_global_right_analog[player_index]) {
+            pad_info.mAnlg[1].x = 0.0f;
+            pad_info.mAnlg[1].y = 0.0f;
+        }
+    }
+    __except (GetExceptionCode() == EXCEPTION_ACCESS_VIOLATION ? EXCEPTION_EXECUTE_HANDLER : EXCEPTION_CONTINUE_SEARCH) {
+    }
+
+    last_global_routed_buttons[player_index] = routed_buttons;
+    last_global_right_analog[player_index] = frame.has_right_analog;
 }
 
 void set_playback_status(const std::string& message) {
@@ -2258,6 +2974,30 @@ void apply_force_style_action(const KeyboardMacroFrame& frame) {
     }
 }
 
+void apply_character_switch_action(const KeyboardMacroFrame& frame) {
+    if (!frame.character_switch) {
+        return;
+    }
+
+    if (CharSwitcher::request_macro_switch()) {
+        set_playback_status("Character switch requested.");
+    }
+    else {
+        set_playback_status("Character Switcher is not enabled or ready.");
+    }
+}
+
+void apply_one_hit_kill_action(const KeyboardMacroFrame& frame) {
+    if (frame.one_hit_kill_toggle) {
+        HealthSettings::one_hit_kill = !HealthSettings::one_hit_kill;
+        set_playback_status(HealthSettings::one_hit_kill ? "One Hit Kill enabled." : "One Hit Kill disabled.");
+    }
+    else if (frame.one_hit_kill_set) {
+        HealthSettings::one_hit_kill = frame.one_hit_kill_value;
+        set_playback_status(HealthSettings::one_hit_kill ? "One Hit Kill enabled." : "One Hit Kill disabled.");
+    }
+}
+
 bool is_player_grounded(uPlayer* player) {
     if (!player) {
         return false;
@@ -2664,11 +3404,28 @@ uint32_t KeyboardMacro::capture_snapshot_vkey = DEFAULT_CAPTURE_SNAPSHOT_VKEY;
 uint32_t KeyboardMacro::load_snapshot_vkey = DEFAULT_LOAD_SNAPSHOT_VKEY;
 uint32_t KeyboardMacro::load_snapshot_play_vkey = DEFAULT_LOAD_SNAPSHOT_PLAY_VKEY;
 uint32_t KeyboardMacro::snapshot_play_delay_ticks = POSITION_SNAPSHOT_LOAD_TICKS;
+uint32_t KeyboardMacro::action_button_map[MACRO_ACTION_COUNT] = {
+    PAD_BUTTON_Y,
+    PAD_BUTTON_X,
+    PAD_BUTTON_A,
+    PAD_BUTTON_B,
+    PAD_BUTTON_B,
+    PAD_BUTTON_L1,
+    PAD_BUTTON_R1,
+    PAD_BUTTON_L2,
+    PAD_BUTTON_R2,
+    PAD_BUTTON_SELECT,
+    PAD_BUTTON_L3,
+    PAD_BUTTON_R3,
+};
+bool KeyboardMacro::auto_reload_file = false;
+bool KeyboardMacro::stop_macro_on_game_pause = false;
 uint32_t KeyboardMacro::playback_slot = PLAYBACK_SLOT_MAIN;
 uint32_t KeyboardMacro::selected_clip_index = 0;
 uint32_t KeyboardMacro::loaded_clip_index = INVALID_CLIP_INDEX;
 bool KeyboardMacro::macro_exceed_active = false;
 uint32_t KeyboardMacro::macro_exceed_latch_ticks = 0;
+uint32_t KeyboardMacro::macro_change_target_latch_ticks = 0;
 bool KeyboardMacro::screen_pause_active = false;
 bool KeyboardMacro::screen_pause_restore_valid = false;
 float KeyboardMacro::screen_pause_restore_speed = 1.0f;
@@ -2690,6 +3447,9 @@ void __stdcall KeyboardMacro::on_pad_update_tick(cPeripheral* peripheral) {
     if (macro_exceed_latch_ticks > 0) {
         --macro_exceed_latch_ticks;
         update_macro_exceed_active_from_latch();
+    }
+    if (macro_change_target_latch_ticks > 0) {
+        --macro_change_target_latch_ticks;
     }
 
     tick_snapshot_play_delay();
@@ -2736,6 +3496,23 @@ uint32_t __stdcall KeyboardMacro::on_player_input_tick(uPlayer* player, void* in
         return inputs;
     }
     return inputs;
+}
+
+void __stdcall KeyboardMacro::on_player_input_press_written(uPlayer* player) {
+    if (!player || macro_change_target_latch_ticks == 0) {
+        return;
+    }
+
+    __try {
+        if (player != get_local_player_safe()) {
+            return;
+        }
+
+        player->inputPress[0] |= 0x20;
+        macro_change_target_latch_ticks = 0;
+    }
+    __except (GetExceptionCode() == EXCEPTION_ACCESS_VIOLATION ? EXCEPTION_EXECUTE_HANDLER : EXCEPTION_CONTINUE_SEARCH) {
+    }
 }
 
 void KeyboardMacro::write_test_input(cPeripheral* peripheral, uint32_t player_index) {
@@ -2787,21 +3564,29 @@ void KeyboardMacro::write_test_input(cPeripheral* peripheral, uint32_t player_in
 
     auto* player = get_local_player_safe();
     const bool is_nero = is_nero_player_safe(player);
-    const bool l2_requested = (buttons & PAD_BUTTON_L2) != 0;
-    const bool exceed_requested = macro_frame.exceed || (is_nero && l2_requested);
+    const bool l2_exceed_requested = (buttons & PAD_BUTTON_L2) != 0 && macro_frame.l2_exceed_compat;
+    const bool exceed_requested = macro_frame.exceed || (is_nero && l2_exceed_requested);
 
     const uint32_t base_buttons = peripheral->mPadBtnOn;
     uint32_t injected_buttons = buttons;
-    if (is_nero && l2_requested) {
+    if (is_nero && l2_exceed_requested) {
         injected_buttons &= ~PAD_BUTTON_L2;
     }
     const uint32_t output_buttons = base_buttons | injected_buttons;
     const uint32_t previous_buttons = last_buttons[player_index];
+    const uint32_t routed_global_buttons = macro_frame.global_buttons;
+    const uint32_t previous_global_buttons = last_global_routed_buttons[player_index];
+    const bool previous_change_target_action = last_change_target_action[player_index];
 
     peripheral->mPadBtnOn = output_buttons;
     peripheral->mPadBtnTrg = output_buttons & ~previous_buttons;
     peripheral->mPadBtnRel = previous_buttons & ~output_buttons;
     apply_button_press_values(peripheral, output_buttons);
+
+    if (macro_frame.change_target && !previous_change_target_action) {
+        queue_macro_change_target_request();
+    }
+    apply_global_pad_route_for_macro(macro_frame, routed_global_buttons, previous_global_buttons, player_index);
 
     if (exceed_requested) {
         queue_macro_exceed_request();
@@ -2815,17 +3600,32 @@ void KeyboardMacro::write_test_input(cPeripheral* peripheral, uint32_t player_in
         peripheral->mIsHold = false;
     }
 
+    if (macro_frame.has_right_analog) {
+        peripheral->mAnlgR.x = clamp_analog((int)peripheral->mAnlgR.x + macro_frame.right_x);
+        peripheral->mAnlgR.y = clamp_analog((int)peripheral->mAnlgR.y + macro_frame.right_y);
+        update_analog_info_for_macro(&peripheral->mAnlgR);
+    }
+
     apply_screen_pause_action(macro_frame);
     apply_force_style_action(macro_frame);
+    apply_character_switch_action(macro_frame);
+    apply_one_hit_kill_action(macro_frame);
 
     last_buttons[player_index] = output_buttons;
+    last_change_target_action[player_index] = macro_frame.change_target;
     update_input_active();
 }
 
 void KeyboardMacro::reset_input_state() {
     std::fill_n(last_buttons, 4, 0);
+    std::fill_n(last_change_target_action, 4, false);
+    for (uint32_t player_index = 0; player_index < 4; ++player_index) {
+        clear_global_macro_route(player_index);
+    }
     macro_exceed_active = false;
     macro_exceed_latch_ticks = 0;
+    macro_change_target_latch_ticks = 0;
+    CharSwitcher::clear_macro_switch_request();
     playback_frame_index = 0;
     for (auto& frame : playback_frames) {
         frame.wait_elapsed_ticks = 0;
@@ -3181,6 +3981,55 @@ bool KeyboardMacro::load_playback_file() {
             continue;
         }
 
+        if (command == "CHARACTER_SWITCH" || command == "SWITCH_CHARACTER" || command == "CHAR_SWITCH" ||
+            command == "CHARACTER_SWAP" || command == "SWAP_CHARACTER") {
+            std::string extra{};
+            if (stream >> extra) {
+                return fail_with_message("Line %u: invalid CHARACTER_SWITCH command.", line_number);
+            }
+
+            if (!append_playback_frames(current_clip.frames, 1, frame_from_character_switch())) {
+                set_playback_status("Macro file is too long.");
+                clear_failed_load();
+                return false;
+            }
+
+            continue;
+        }
+
+        if (command == "ONE_HIT_KILL" || command == "ONEHITKILL" || command == "OHK") {
+            std::string action_token{};
+            std::string extra{};
+            stream >> action_token >> extra;
+            if (!extra.empty()) {
+                return fail_with_message("Line %u: invalid ONE_HIT_KILL command.", line_number);
+            }
+
+            const auto action = normalize_button_token(action_token);
+            bool toggle = false;
+            bool value = false;
+            if (action.empty() || action == "TOGGLE") {
+                toggle = true;
+            }
+            else if (action == "ON" || action == "ENABLE" || action == "ENABLED" || action == "TRUE" || action == "1") {
+                value = true;
+            }
+            else if (action == "OFF" || action == "DISABLE" || action == "DISABLED" || action == "FALSE" || action == "0") {
+                value = false;
+            }
+            else {
+                return fail_with_message("Line %u: invalid ONE_HIT_KILL command.", line_number);
+            }
+
+            if (!append_playback_frames(current_clip.frames, 1, frame_from_one_hit_kill(toggle, value))) {
+                set_playback_status("Macro file is too long.");
+                clear_failed_load();
+                return false;
+            }
+
+            continue;
+        }
+
         if (command == "SET") {
             std::string expression{};
             std::getline(stream, expression);
@@ -3229,6 +4078,7 @@ bool KeyboardMacro::load_playback_file() {
     std::snprintf(message, sizeof(message), "Loaded %u clips; selected clip has %u ticks.", (uint32_t)playback_clips.size(), (uint32_t)playback_frames.size());
     set_playback_status(message);
     strncpy_s(loaded_playback_path, file_path.c_str(), _TRUNCATE);
+    remember_macro_file_write_time(file_path);
 
     return !playback_frames.empty();
 }
@@ -3382,12 +4232,57 @@ void KeyboardMacro::stop_all_input() {
     finalize_playback_timer();
     macro_exceed_active = false;
     macro_exceed_latch_ticks = 0;
+    macro_change_target_latch_ticks = 0;
+    CharSwitcher::clear_macro_switch_request();
     playback_frame_index = 0;
     clear_last_peripheral_output();
     clear_input_frames = 4;
     reset_hit_confirmed_wait_state();
     update_input_active();
     set_playback_status("Playback stopped; clearing input.");
+}
+
+void KeyboardMacro::check_auto_reload_file() {
+    if (!mod_enabled || !auto_reload_file || playback_enabled || snapshot_play_pending_clip_index != INVALID_CLIP_INDEX) {
+        return;
+    }
+
+    const std::string file_path = resolve_playback_path();
+    uint64_t write_time = 0;
+    if (!get_file_write_time(file_path, write_time)) {
+        return;
+    }
+
+    if (known_macro_file_time_path != file_path || known_macro_file_write_time == 0) {
+        known_macro_file_time_path = file_path;
+        known_macro_file_write_time = write_time;
+        return;
+    }
+
+    if (write_time == known_macro_file_write_time) {
+        return;
+    }
+
+    known_macro_file_write_time = write_time;
+    if (reload_playback_file()) {
+        set_playback_status("Macro file changed; auto-reloaded.");
+    }
+}
+
+void KeyboardMacro::check_pause_interrupt() {
+    const bool game_paused = is_game_paused_safe();
+
+    if (!mod_enabled || !stop_macro_on_game_pause) {
+        last_game_pause_state = game_paused;
+        return;
+    }
+
+    if (game_paused && !last_game_pause_state && (playback_enabled || snapshot_play_pending_clip_index != INVALID_CLIP_INDEX)) {
+        stop_all_input();
+        set_playback_status("Playback stopped because the game paused.");
+    }
+
+    last_game_pause_state = game_paused;
 }
 
 void KeyboardMacro::on_frame(fmilliseconds& dt) {
@@ -3403,6 +4298,8 @@ void KeyboardMacro::on_frame(fmilliseconds& dt) {
         set_playback_status("Keyboard Macro ready.");
     }
 
+    check_pause_interrupt();
+    check_auto_reload_file();
     check_hotkeys();
     if (position_snapshot_load_ticks > 0) {
         if (apply_position_snapshot(false, false)) {
@@ -3526,6 +4423,42 @@ void KeyboardMacro::on_gui_frame(int display) {
                 }
             }
 
+            if (ImGui::CollapsingHeader(_("Action Mapping"))) {
+                ImGui::TextWrapped(_("Action names such as MELEE and LOCK_ON use this mapping. Match it to DMC4's in-game controller settings; this does not remap the game by itself."));
+                size_t action_count = 0;
+                const auto* actions = macro_action_choices(action_count);
+                size_t button_count = 0;
+                const auto* buttons = macro_button_choices(button_count);
+                for (uint32_t action_index = 0; action_index < action_count && action_index < MACRO_ACTION_COUNT; ++action_index) {
+                    ImGui::PushID((int)action_index);
+                    const auto current_button = action_button_map[action_index];
+                    if (ImGui::BeginCombo(actions[action_index].label, macro_button_label(current_button))) {
+                        for (size_t button_index = 0; button_index < button_count; ++button_index) {
+                            const bool is_selected = current_button == buttons[button_index].button;
+                            if (ImGui::Selectable(buttons[button_index].label, is_selected)) {
+                                action_button_map[action_index] = buttons[button_index].button;
+                                reset_input_state();
+                                reload_playback_file();
+                                set_playback_status("Action mapping updated.");
+                            }
+                            if (is_selected) {
+                                ImGui::SetItemDefaultFocus();
+                            }
+                        }
+                        ImGui::EndCombo();
+                    }
+                    ImGui::PopID();
+                }
+                if (ImGui::Button(_("Reset Action Mapping"))) {
+                    for (uint32_t action_index = 0; action_index < MACRO_ACTION_COUNT; ++action_index) {
+                        action_button_map[action_index] = DEFAULT_ACTION_BUTTON_MAP[action_index];
+                    }
+                    reset_input_state();
+                    reload_playback_file();
+                    set_playback_status("Action mapping restored to default.");
+                }
+            }
+
             if (!keyboard_macro_gameplay_ready()) {
                 suspend_keyboard_macro_runtime_for_transition();
                 ImGui::TextWrapped(_("Macro status: %s"), playback_status);
@@ -3535,6 +4468,12 @@ void KeyboardMacro::on_gui_frame(int display) {
             }
 
             ImGui::SeparatorText(_("Playback"));
+            ImGui::Checkbox(_("Auto reload Macro file"), &auto_reload_file);
+            ImGui::SameLine();
+            help_marker(_("Reload the selected macro file after it is saved. Auto reload waits until playback is stopped."));
+            ImGui::Checkbox(_("Stop Macro when game pauses"), &stop_macro_on_game_pause);
+            ImGui::SameLine();
+            help_marker(_("Stop macro playback when DMC4 opens the pause menu so it will not continue after unpausing."));
             if (ImGui::Button(_("Reload Macro File"))) {
                 reload_playback_file();
             }
@@ -3787,6 +4726,16 @@ void KeyboardMacro::on_config_load(const utility::Config& cfg) {
         cfg.get<uint32_t>("keyboard_macro_snapshot_play_delay_ticks").value_or(POSITION_SNAPSHOT_LOAD_TICKS),
         MAX_SNAPSHOT_PLAY_DELAY_TICKS);
     restore_resources_snapshot = cfg.get<bool>("keyboard_macro_restore_resources").value_or(false);
+    auto_reload_file = cfg.get<bool>("keyboard_macro_auto_reload_file").value_or(false);
+    stop_macro_on_game_pause = cfg.get<bool>("keyboard_macro_stop_on_game_pause").value_or(false);
+    last_game_pause_state = is_game_paused_safe();
+    size_t action_count = 0;
+    const auto* actions = macro_action_choices(action_count);
+    for (uint32_t action_index = 0; action_index < action_count && action_index < MACRO_ACTION_COUNT; ++action_index) {
+        action_button_map[action_index] = sanitize_macro_button(
+            cfg.get<uint32_t>(actions[action_index].config_key).value_or(actions[action_index].default_button),
+            actions[action_index].default_button);
+    }
     if (m_hotkeys.size() >= 6) {
         if (!cfg.get("keyboard_macro_reload_file_key")) {
             m_hotkeys[0]->m_default_keys = { reload_vkey };
@@ -3859,6 +4808,13 @@ void KeyboardMacro::on_config_save(utility::Config& cfg) {
     cfg.set<uint32_t>("keyboard_macro_load_snapshot_play_vkey", load_snapshot_play_vkey);
     cfg.set<uint32_t>("keyboard_macro_snapshot_play_delay_ticks", snapshot_play_delay_ticks);
     cfg.set<bool>("keyboard_macro_restore_resources", restore_resources_snapshot);
+    cfg.set<bool>("keyboard_macro_auto_reload_file", auto_reload_file);
+    cfg.set<bool>("keyboard_macro_stop_on_game_pause", stop_macro_on_game_pause);
+    size_t action_count = 0;
+    const auto* actions = macro_action_choices(action_count);
+    for (uint32_t action_index = 0; action_index < action_count && action_index < MACRO_ACTION_COUNT; ++action_index) {
+        cfg.set<uint32_t>(actions[action_index].config_key, action_button_map[action_index]);
+    }
     cfg.set<uint32_t>("keyboard_macro_slot", playback_slot);
     cfg.set<uint32_t>("keyboard_macro_clip_index", selected_clip_index);
     cfg.set("keyboard_macro_custom_path", playback_path);

--- a/src/mods/KeyboardMacro.hpp
+++ b/src/mods/KeyboardMacro.hpp
@@ -10,13 +10,23 @@ class uPlayer;
 
 struct KeyboardMacroFrame {
     uint32_t buttons = 0;
+    uint32_t global_buttons = 0;
     short left_x = 0;
     short left_y = 0;
     bool has_left_analog = false;
+    short right_x = 0;
+    short right_y = 0;
+    bool has_right_analog = false;
     bool exceed = false;
+    bool l2_exceed_compat = false;
     bool screen_pause = false;
     bool screen_resume = false;
     bool screen_pause_toggle = false;
+    bool change_target = false;
+    bool character_switch = false;
+    bool one_hit_kill_set = false;
+    bool one_hit_kill_value = false;
+    bool one_hit_kill_toggle = false;
     bool force_style = false;
     int forced_style = -1;
     uint32_t wait_condition = 0;
@@ -50,11 +60,15 @@ public:
     static uint32_t load_snapshot_vkey;
     static uint32_t load_snapshot_play_vkey;
     static uint32_t snapshot_play_delay_ticks;
+    static uint32_t action_button_map[12];
+    static bool auto_reload_file;
+    static bool stop_macro_on_game_pause;
     static uint32_t playback_slot;
     static uint32_t selected_clip_index;
     static uint32_t loaded_clip_index;
     static bool macro_exceed_active;
     static uint32_t macro_exceed_latch_ticks;
+    static uint32_t macro_change_target_latch_ticks;
     static bool screen_pause_active;
     static bool screen_pause_restore_valid;
     static float screen_pause_restore_speed;
@@ -69,6 +83,7 @@ public:
     static void __stdcall on_pad_update_tick(cPeripheral* peripheral);
     static void __stdcall on_player_pad_update(cPeripheral* peripheral);
     static uint32_t __stdcall on_player_input_tick(uPlayer* player, void* input_state, uint32_t inputs);
+    static void __stdcall on_player_input_press_written(uPlayer* player);
 
     std::optional<std::string> on_initialize() override;
     void on_frame(fmilliseconds& dt) override;
@@ -90,6 +105,8 @@ private:
     static void tick_snapshot_play_delay();
     static void stop_all_input();
     static void update_input_active();
+    static void check_auto_reload_file();
+    static void check_pause_interrupt();
     static std::string resolve_playback_path();
     static void handle_hotkey_actions(
         bool reload_pressed,


### PR DESCRIPTION
﻿Small update based on testers' feedback.

I tightened the Keyboard Macro input path and documentation a bit more:

- expanded the player-facing docs around ticks, direction aliases, action mapping, and camera controls
- added semantic action names such as MELEE, JUMP, LOCK_ON, CHANGE_TARGET, and RESET_CAMERA
- added proper global-pad support for reset camera, right-stick camera movement, and change target
- added optional auto-reload for macro files
- added an option to stop macro playback when the game is paused
- added a few script actions such as character switch, one hit kill toggle, and slow-walk analog movement
