### PR TITLE
Fix public Macro input and localized layouts

### DIFF
--- a/docs/macro.txt
+++ b/docs/macro.txt
@@ -1,0 +1,30 @@
+# DMC4 Macro examples.
+# Put this file next to DevilMayCry4_DX9.exe.
+# Read macro_release.html first, then use macro_script_reference.html as a lookup manual.
+#
+# Action names such as JUMP and MELEE use the matching Nero or Dante
+# Action Mapping table in the Macro GUI.
+
+# Press V, or enable Gamepad Hotkeys and hold Back/Select before A / Cross.
+[V][A/CROSS][Nero] Jump test
+TAP JUMP
+
+# TAP lines run in sequence. WAIT adds a larger gap before the next input.
+[F1][Nero] Jump then melee
+TAP JUMP
+WAIT 10
+TAP MELEE
+
+# HOLD remains active until RELEASE, CLEAR, or Stop Macro.
+[F2][Nero] Lock-on movement
+HOLD LOCK_ON
+HOLD MOVE_RIGHT
+WAIT 20
+RELEASE MOVE_RIGHT
+RELEASE LOCK_ON
+
+# Dante action names use Dante Action Mapping.
+[F3][Dante] Melee then style action
+TAP MELEE
+WAIT 10
+TAP STYLE_ACTION

--- a/docs/macro_release.html
+++ b/docs/macro_release.html
@@ -126,6 +126,32 @@ body {
   padding: 11px 13px;
   font-weight: 600;
 }
+.task-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  margin: 0.9em 0;
+}
+.task-link {
+  display: block;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  padding: 10px 12px;
+  background: var(--code-bg);
+  color: var(--text);
+  font-weight: 600;
+}
+.task-link:hover {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  text-decoration: none;
+}
+.task-link small {
+  display: block;
+  margin-top: 2px;
+  color: var(--muted);
+  font-weight: 400;
+}
 a { color: var(--accent); text-decoration: none; }
 a:hover { text-decoration: underline; }
 h1, h2, h3, h4 { line-height: 1.25; margin: 1.6em 0 0.55em; }
@@ -247,6 +273,7 @@ th {
   .page { padding: 14px 10px 36px; }
   .content { padding: 18px 14px; }
   .toc ul { columns: 1; }
+  .task-grid { grid-template-columns: 1fr; }
   h1 { font-size: 25px; }
   h2 { font-size: 21px; }
   .heading-link { opacity: 1; }
@@ -259,6 +286,7 @@ th {
 <div class="doc-switch">
 <strong>DMC4 Macro Docs</strong>
 <a href="macro_script_reference.html">Open Script Reference</a>
+<a href="https://github.com/muhopensores/dmc4_hook/releases/latest">Official Hook Release</a>
 </div>
 <label class="search-label" for="doc-search">Search this page</label>
 <input class="doc-search" id="doc-search" type="search" placeholder="TAP, MOVE_LEFT, Snapshot..." autocomplete="off">
@@ -267,8 +295,8 @@ th {
 <h2>Contents</h2>
 <ul>
 <li class="toc-level-1"><a href="#dmc4-macro-battle-snapshot-player-guide">DMC4 Macro + Battle Snapshot Player Guide</a></li>
-<li class="toc-level-2"><a href="#start-here">Start Here</a></li>
-<li class="toc-level-2"><a href="#reading-path">Reading Path</a></li>
+<li class="toc-level-2"><a href="#quick-start">Quick Start</a></li>
+<li class="toc-level-2"><a href="#find-what-you-need">Find What You Need</a></li>
 <li class="toc-level-2"><a href="#install">Install</a></li>
 <li class="toc-level-2"><a href="#ten-minute-first-macro">Ten-Minute First Macro</a></li>
 <li class="toc-level-2"><a href="#the-input-rule">The Input Rule</a></li>
@@ -301,61 +329,49 @@ th {
 <article class="content" id="document-content">
 <h1 id="dmc4-macro-battle-snapshot-player-guide" data-search-heading="DMC4 Macro + Battle Snapshot Player Guide">DMC4 Macro + Battle Snapshot Player Guide<a class="heading-link" href="#dmc4-macro-battle-snapshot-player-guide" aria-label="Link to DMC4 Macro + Battle Snapshot Player Guide">#</a></h1>
 
-<p>Use this guide to install the build, run your first macro, understand controller inputs, and choose a practice workflow. If you are new to macro scripts, start from the top and stop after <code>Timing Basics</code>; Snapshot, Setup, and advanced animation waits can wait until your first simple route works.</p>
+<p>Use this guide to run your first macro, understand controller inputs, and choose a repeatable practice workflow. New players can begin with the steps below and open the detailed sections only when they need them.</p>
 
-<p>For every accepted input name, command, alias, <code>WAIT_UNTIL</code> condition, and <code>[Setup]</code> field, open <code>macro_script_reference.html</code>.</p>
+<h2 id="quick-start" data-search-heading="Quick Start">Quick Start<a class="heading-link" href="#quick-start" aria-label="Link to Quick Start">#</a></h2>
 
-<h2 id="start-here" data-search-heading="Start Here">Start Here<a class="heading-link" href="#start-here" aria-label="Link to Start Here">#</a></h2>
+<ol>
+<li>Put <code>dinput8.dll</code> and <code>macro.txt</code> next to <code>DevilMayCry4_DX9.exe</code>. See <a href="#install">Install</a> for download links and details.</li>
+<li>Open the Hook GUI, go to <code>Training -&gt; Macro</code>, enable <code>Macro</code>, and make sure <code>Nero Action Mapping -&gt; JUMP</code> matches Nero's Jump button in DMC4.</li>
+<li>Put the clip below in <code>macro.txt</code>, save the file, select <code>Jump test</code> in the GUI, play as Nero, and press <code>V</code>.</li>
+</ol>
 
-<p>Macro reads <code>macro*.txt</code> files and sends input through DMC4's controller input layer. It does not send Windows keyboard events.</p>
+<div class="code-block"><button class="copy-code" type="button">Copy</button><pre><code class="language-text">[V][Nero] Jump test
+TAP JUMP</code></pre></div>
 
-<p>Think of a macro file as an automatic controller note sheet. Macro reads from top to bottom and does exactly what the lines say: press this input, keep holding that input, wait a short time, release this input, or run a Hook action.</p>
+<div class="callout">Nero should jump once. If another action happens, fix Nero Action Mapping first. <code>TAP JUMP</code> follows that mapping; a physical name such as <code>TAP A</code> always presses A / Cross.</div>
 
-<p>The build also includes:</p>
+<p>Macro is an automatic controller note sheet: it reads a clip from top to bottom and sends DMC4 controller input. It does not send Windows keyboard events. Continue with <a href="#ten-minute-first-macro">Ten-Minute First Macro</a> to add waits, held inputs, simultaneous inputs, and an optional controller shortcut.</p>
 
-<ul>
-<li>Battle Snapshot for repeatable same-room practice</li>
-<li>Macro Setup blocks for text-based player, camera, and enemy placement</li>
-<li>Animation Overlay for observing animation state and timing</li>
-<li>Macro Playback Overlay for seeing the current line, next line, held inputs, and progress</li>
-<li>Character Switcher support for macros that intentionally use both characters</li>
-</ul>
+<h2 id="find-what-you-need" data-search-heading="Find What You Need">Find What You Need<a class="heading-link" href="#find-what-you-need" aria-label="Link to Find What You Need">#</a></h2>
+
+<div class="task-grid">
+<a class="task-link" href="#ten-minute-first-macro">Write my first combo<small>Learn TAP, WAIT, HOLD, RELEASE, and playback debugging.</small></a>
+<a class="task-link" href="#gamepad-shortcuts">Start clips with a controller<small>Use Back/Select plus one shortcut button.</small></a>
+<a class="task-link" href="#the-input-rule">Know what follows TAP or HOLD<small>Separate input names from complete Hook commands.</small></a>
+<a class="task-link" href="#buttons-and-sticks">Use sticks or D-pad<small>Find movement, camera, stick-click, and D-pad names.</small></a>
+<a class="task-link" href="#combining-inputs-with">Press several inputs together<small>Use + for same-tick controller input.</small></a>
+<a class="task-link" href="#timing-basics">Control combo timing<small>Understand WAIT, WAIT_UNTIL, and held input.</small></a>
+<a class="task-link" href="#battle-snapshot">Repeat the same encounter<small>Capture and restore supported battle state.</small></a>
+<a class="task-link" href="#macro-setup">Prepare a scene from text<small>Place the player, camera, and supported enemies.</small></a>
+<a class="task-link" href="#troubleshooting">Fix a script problem<small>Look up common symptoms and likely causes.</small></a>
+<a class="task-link" href="macro_script_reference.html">Look up every command<small>Open the complete input, command, wait, and Setup reference.</small></a>
+</div>
 
 <p>Battle Snapshot and Macro Setup are practice tools, not full savestates. They do not restore every projectile, effect, animation, enemy AI state, or mission script.</p>
 
-<h2 id="reading-path" data-search-heading="Reading Path">Reading Path<a class="heading-link" href="#reading-path" aria-label="Link to Reading Path">#</a></h2>
-
-<p>For a first macro, read only:</p>
-
-<ol>
-<li><code>Install</code></li>
-<li><code>Ten-Minute First Macro</code></li>
-<li><code>The Input Rule</code></li>
-<li><code>Buttons And Sticks</code></li>
-<li><code>Combining Inputs With +</code></li>
-<li><code>Timing Basics</code></li>
-</ol>
-
-<p>After that, use <code>Macro Playback Overlay</code> when something does not happen at the expected line.</p>
-
-<p>For regular combo writing, add:</p>
-
-<ul>
-<li><code>Character Tags And Action Mapping</code></li>
-<li><code>Gamepad Shortcuts</code></li>
-<li><code>Simple Recipes</code></li>
-</ul>
-
-<p>For repeatable practice setups, read:</p>
-
-<ul>
-<li><code>Battle Snapshot</code></li>
-<li><code>Macro Setup</code></li>
-</ul>
-
-<p>For advanced timing, open <code>macro_script_reference.html</code> and look up <code>WAIT_UNTIL</code>, <code>ANIM_FRAME</code>, <code>MOVEID2</code>, and the troubleshooting index.</p>
-
 <h2 id="install" data-search-heading="Install">Install<a class="heading-link" href="#install" aria-label="Link to Install">#</a></h2>
+
+<p>Required files:</p>
+
+<ul>
+<li><a href="https://github.com/muhopensores/dmc4_hook/releases/latest"><code>dinput8.dll</code> from the latest official Hook release</a></li>
+<li><a href="https://raw.githubusercontent.com/muhopensores/dmc4_hook/struct-revamp/macro.txt"><code>macro.txt</code> sample file</a>, or a new plain-text file with that name</li>
+<li><code>macro_release.html</code> and <code>macro_script_reference.html</code> kept together if you want the links between both guides to work offline</li>
+</ul>
 
 <ol>
 <li>Close the game.</li>
@@ -375,6 +391,8 @@ macro_boss_practice.txt</code></pre></div>
 <p>Use <code>Custom Macro File</code> when the file is stored somewhere else.</p>
 
 <h2 id="ten-minute-first-macro" data-search-heading="Ten-Minute First Macro">Ten-Minute First Macro<a class="heading-link" href="#ten-minute-first-macro" aria-label="Link to Ten-Minute First Macro">#</a></h2>
+
+<p>Before testing action names, open <code>Training -&gt; Macro -&gt; Nero Action Mapping</code> and match <code>JUMP</code>, <code>MELEE</code>, and <code>LOCK_ON</code> to Nero's current DMC4 controller settings. Action names follow this table; physical button names such as <code>A</code> or <code>Y</code> do not.</p>
 
 <p>Create or edit <code>macro.txt</code>:</p>
 
@@ -412,8 +430,6 @@ TAP JUMP</code></pre></div>
 <p>Nero should jump once.</p>
 
 <p>If you used the controller shortcut version, also enable <code>Gamepad Hotkeys</code>, then hold <code>Back/Select</code> first and press <code>A / Cross</code>. Pressing <code>A / Cross</code> first will not trigger the shortcut. While <code>Gamepad Hotkeys</code> is enabled, Back/Select is reserved by Macro shortcuts and will not trigger its normal in-game action manually.</p>
-
-<p>If a different action happens, open <code>Nero Action Mapping</code> and set <code>JUMP</code> to the same button used by Nero in DMC4's controller settings.</p>
 
 <p>For Dante, change the header to:</p>
 

--- a/docs/macro_release.html
+++ b/docs/macro_release.html
@@ -369,8 +369,8 @@ TAP JUMP</code></pre></div>
 
 <ul>
 <li><a href="https://github.com/muhopensores/dmc4_hook/releases/latest"><code>dinput8.dll</code> from the latest official Hook release</a></li>
-<li><a href="https://raw.githubusercontent.com/muhopensores/dmc4_hook/struct-revamp/macro.txt"><code>macro.txt</code> sample file</a>, or a new plain-text file with that name</li>
-<li><code>macro_release.html</code> and <code>macro_script_reference.html</code> kept together if you want the links between both guides to work offline</li>
+<li><a href="macro.txt" download><code>macro.txt</code> starter template</a>, or a new plain-text file with that name</li>
+<li><code>macro.txt</code>, <code>macro_release.html</code>, and <code>macro_script_reference.html</code> kept together if you want their links to work offline</li>
 </ul>
 
 <ol>

--- a/docs/macro_script_reference.html
+++ b/docs/macro_script_reference.html
@@ -258,7 +258,8 @@ th {
 <aside class="sidebar">
 <div class="doc-switch">
 <strong>DMC4 Macro Docs</strong>
-<a href="macro_release.html">Open Player Guide</a>
+<a href="macro_release.html#find-what-you-need">Choose A Task In The Player Guide</a>
+<a href="https://github.com/muhopensores/dmc4_hook/releases/latest">Official Hook Release</a>
 </div>
 <label class="search-label" for="doc-search">Search this page</label>
 <input class="doc-search" id="doc-search" type="search" placeholder="TAP, MOVE_LEFT, Snapshot..." autocomplete="off">
@@ -300,7 +301,7 @@ th {
 <article class="content" id="document-content">
 <h1 id="macrotxt-script-reference" data-search-heading="macro*.txt Script Reference">macro*.txt Script Reference<a class="heading-link" href="#macrotxt-script-reference" aria-label="Link to macro*.txt Script Reference">#</a></h1>
 
-<p>This is the complete lookup reference for Macro. For installation, a first macro, controller explanations, Battle Snapshot, and common workflows, read <code>macro_release.html</code>.</p>
+<p>This is the complete lookup reference for Macro. For installation, a first macro, controller explanations, Battle Snapshot, and common workflows, open <a href="macro_release.html#find-what-you-need">Find What You Need in the Player Guide</a>.</p>
 
 <p>Use the page contents or browser search to jump directly to an input name, command, condition, or error. This page is a lookup manual, not the best first reading order.</p>
 

--- a/docs/macro_script_reference.html
+++ b/docs/macro_script_reference.html
@@ -301,7 +301,7 @@ th {
 <article class="content" id="document-content">
 <h1 id="macrotxt-script-reference" data-search-heading="macro*.txt Script Reference">macro*.txt Script Reference<a class="heading-link" href="#macrotxt-script-reference" aria-label="Link to macro*.txt Script Reference">#</a></h1>
 
-<p>This is the complete lookup reference for Macro. For installation, a first macro, controller explanations, Battle Snapshot, and common workflows, open <a href="macro_release.html#find-what-you-need">Find What You Need in the Player Guide</a>.</p>
+<p>This is the complete lookup reference for Macro. For installation, a first macro, controller explanations, Battle Snapshot, and common workflows, open <a href="macro_release.html#find-what-you-need">Find What You Need in the Player Guide</a>. You can also begin with the included <a href="macro.txt" download><code>macro.txt</code> starter template</a>.</p>
 
 <p>Use the page contents or browser search to jump directly to an input name, command, condition, or error. This page is a lookup manual, not the best first reading order.</p>
 

--- a/src/mods/AnimationOverlay.cpp
+++ b/src/mods/AnimationOverlay.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdio>
+#include <initializer_list>
 #include <string>
 
 bool AnimationOverlay::mod_enabled = false;
@@ -158,9 +159,22 @@ void draw_shadow_text(const std::string& text, const ImVec4& color) {
     ImGui::TextColored(color, "%s", text.c_str());
 }
 
-void draw_key_value_line(const char* label, const std::string& value, const ImVec4& label_color, const ImVec4& value_color) {
+float key_value_column(std::initializer_list<const char*> labels) {
+    float label_width = 0.0f;
+    for (const char* label : labels) {
+        label_width = std::max(label_width, ImGui::CalcTextSize(label).x);
+    }
+    return ImGui::GetCursorPosX() + label_width + ImGui::GetStyle().ItemSpacing.x;
+}
+
+void draw_key_value_line(
+    const char* label,
+    const std::string& value,
+    float value_column,
+    const ImVec4& label_color,
+    const ImVec4& value_color) {
     ImGui::TextColored(label_color, "%s", label);
-    ImGui::SameLine(115.0f);
+    ImGui::SameLine(value_column);
     draw_shadow_text(value, value_color);
 }
 
@@ -189,7 +203,7 @@ std::string format_frame_line(const AnimationOverlayState& state) {
 
 std::string format_part_line(const AnimationOverlayState& state) {
     char buffer[64]{};
-    std::snprintf(buffer, sizeof(buffer), _("Part %u"), state.move_part);
+    std::snprintf(buffer, sizeof(buffer), "%u", state.move_part);
     return buffer;
 }
 
@@ -261,20 +275,33 @@ void AnimationOverlay::on_frame(fmilliseconds& dt) {
     draw_frame_progress_bar(state, palette);
 
     ImGui::UpdateCurrentFontSize(1.36f * ImGui::GetStyle().FontSizeBase);
-    draw_key_value_line(_("MoveID2"), format_hex32(state.move_id2), palette.muted, palette.body);
-    draw_key_value_line(_("Anim"), format_hex16(state.anim_id), palette.muted, palette.body);
-    draw_key_value_line(_("Move Part"), format_part_line(state), palette.muted, palette.body);
+    const float primary_value_column = key_value_column({ _("MoveID2"), _("Anim"), _("Move Part") });
+    draw_key_value_line(_("MoveID2"), format_hex32(state.move_id2), primary_value_column, palette.muted, palette.body);
+    draw_key_value_line(_("Anim"), format_hex16(state.anim_id), primary_value_column, palette.muted, palette.body);
+    draw_key_value_line(_("Move Part"), format_part_line(state), primary_value_column, palette.muted, palette.body);
 
     if (show_advanced) {
         ImGui::Separator();
         ImGui::UpdateCurrentFontSize(1.18f * ImGui::GetStyle().FontSizeBase);
-        draw_key_value_line(_("Bank"), format_hex32(state.move_bank), palette.muted, palette.body);
-        draw_key_value_line(_("Ground Raw"), std::to_string(state.grounded_raw), palette.muted, palette.body);
-        draw_key_value_line(_("Ground2"), state.grounded2 ? "1" : "0", palette.muted, palette.body);
-        draw_key_value_line(_("Land Flag"), state.has_collision_land ? (state.collision_land ? "1" : "0") : _("n/a"), palette.muted, palette.body);
+        const float advanced_value_column =
+            key_value_column({ _("Bank"), _("Ground Raw"), _("Ground2"), _("Land Flag"), _("Hitstop") });
+        draw_key_value_line(_("Bank"), format_hex32(state.move_bank), advanced_value_column, palette.muted, palette.body);
+        draw_key_value_line(_("Ground Raw"), std::to_string(state.grounded_raw), advanced_value_column, palette.muted, palette.body);
+        draw_key_value_line(_("Ground2"), state.grounded2 ? "1" : "0", advanced_value_column, palette.muted, palette.body);
+        draw_key_value_line(
+            _("Land Flag"),
+            state.has_collision_land ? (state.collision_land ? "1" : "0") : _("n/a"),
+            advanced_value_column,
+            palette.muted,
+            palette.body);
         char hitstop_buffer[32]{};
         std::snprintf(hitstop_buffer, sizeof(hitstop_buffer), "%.1f", state.hitstop_timer);
-        draw_key_value_line(_("Hitstop"), hitstop_buffer, palette.muted, state.hitstop ? palette.warning : palette.body);
+        draw_key_value_line(
+            _("Hitstop"),
+            hitstop_buffer,
+            advanced_value_column,
+            palette.muted,
+            state.hitstop ? palette.warning : palette.body);
     }
 
     ImGui::UpdateCurrentFontSize(0.0f);

--- a/src/mods/Coop.cpp
+++ b/src/mods/Coop.cpp
@@ -32,7 +32,6 @@ static uintptr_t uCameraCtrl_setup_end = 0x04f76da;
 //std::vector<void*> CamArr;
 //std::vector<void*> HUDArr;
 
-uintptr_t Coop::jmp_ret1 = NULL;
 uintptr_t Coop::jmp_ret2 = NULL;
 uintptr_t Coop::jmp_ret3 = NULL;
 uintptr_t Coop::jmp_ret4 = NULL;
@@ -161,35 +160,13 @@ void __stdcall new_pad_update_func(cPeripheral* peri) {
     update_analog_info(&peri->mAnlgR);
 }
 
-naked void detour1() {
-    _asm {
-            pushad
-            push [esp+0x20+0x4]
-            call Macro::on_pad_update_tick
-            popad
-            cmp byte ptr [Macro::input_active], 1
-            jne coopcheck
-            pushad
-            push [esp+0x20+0x4]
-            call Macro::on_player_pad_update
-            popad
-            jmp handle
-        coopcheck:
-            cmp byte ptr [Coop::mod_enabled], 1
-            jne originalcode
-            pushad
-            push [esp+0x20+0x4]
-            call new_pad_update_func
-            popad
-            jmp handle
-        originalcode:
-            push ebp
-            mov ebp,esp
-            and esp,-0x08
-            jmp [Coop::jmp_ret1]
-        handle:
-            ret 4
+bool __stdcall coop_pad_update_fallback(cPeripheral* peripheral) {
+    if (!Coop::mod_enabled) {
+        return false;
     }
+
+    new_pad_update_func(peripheral);
+    return true;
 }
 
 sDevil4Pad* create_pad(int id) {
@@ -620,11 +597,6 @@ naked void detour12() {//Dante HUD
 }
 
 std::optional<std::string> Coop::on_initialize() {
-    if (!install_hook_offset(0x3AFD10, hook1, &detour1, &jmp_ret1, 6)) { //replace player pad update func
-        spdlog::error("Failed to init Coop mod1\n");
-        return "Failed to init Coop mod1";
-    }
-
     if (!install_hook_offset(0x4AEFA1, hook2, &detour2, &jmp_ret2, 6)) { //call sPad move loop
         spdlog::error("Failed to init Coop mod2\n");
         return "Failed to init Coop mod2";
@@ -682,6 +654,8 @@ std::optional<std::string> Coop::on_initialize() {
     //    return "Failed to init Coop mod4";
     //}
 
+
+    Macro::set_pad_update_fallback(&coop_pad_update_fallback);
 
     //std::thread init([]() {
     //    while (*sDevil4Pad_ptr == nullptr)

--- a/src/mods/Coop.hpp
+++ b/src/mods/Coop.hpp
@@ -19,7 +19,6 @@ public:
     static bool mod_enabled;
     static unsigned int player_num;
 
-    static uintptr_t jmp_ret1;
     static uintptr_t jmp_ret2;
     static uintptr_t jmp_ret3;
     static uintptr_t jmp_ret4;
@@ -44,7 +43,7 @@ public:
     //void on_config_load(const utility::Config& cfg) override;
     //void on_config_save(utility::Config& cfg) override;
 private:
-    std::unique_ptr<FunctionHook> hook1, hook2, hook3, hook4, hook5, hook6, hook7, hook8, hook9, hook10,
+    std::unique_ptr<FunctionHook> hook2, hook3, hook4, hook5, hook6, hook7, hook8, hook9, hook10,
     hook11, hook12;
     std::unique_ptr<Patch> patch1;
 };

--- a/src/mods/Macro.cpp
+++ b/src/mods/Macro.cpp
@@ -432,6 +432,25 @@ uint64_t known_macro_file_size = 0;
 uint32_t gamepad_hotkey_chord_state = 0;
 uint32_t gamepad_hotkey_raw_buttons = 0;
 uint32_t capture_gamepad_hotkey_target = 0;
+static Macro::PadUpdateFallback player_pad_update_fallback = nullptr;
+
+naked void player_pad_update_detour() {
+    _asm {
+            pushad
+            push [esp+0x20+0x4]
+            call Macro::dispatch_player_pad_update
+            test al,al
+            jz originalcode
+            popad
+            ret 4
+        originalcode:
+            popad
+            push ebp
+            mov ebp,esp
+            and esp,-0x08
+            jmp [Macro::player_pad_jmp_ret]
+    }
+}
 
 void update_config_hotkey_vkeys(const std::vector<std::unique_ptr<utility::Hotkey>>& hotkeys);
 std::string trim_copy(const std::string& value);
@@ -6258,11 +6277,32 @@ char Macro::playback_status[256] = "No Macro file loaded.";
 std::vector<MacroClip> Macro::playback_clips{};
 std::vector<MacroFrame> Macro::playback_frames{};
 std::vector<MacroSourceLine> Macro::playback_source_lines{};
+uintptr_t Macro::player_pad_jmp_ret = 0;
 
 std::optional<std::string> Macro::on_initialize() {
     macro_instance = this;
     ensure_keyboard_hotkeys(m_hotkeys);
+
+    if (!install_hook_offset(0x3AFD10, player_pad_hook, &player_pad_update_detour, &player_pad_jmp_ret, 6)) {
+        return "Failed to initialize Macro player input hook";
+    }
+
     return Mod::on_initialize();
+}
+
+bool __stdcall Macro::dispatch_player_pad_update(cPeripheral* peripheral) {
+    on_pad_update_tick(peripheral);
+
+    if (input_active) {
+        on_player_pad_update(peripheral);
+        return true;
+    }
+
+    return player_pad_update_fallback && player_pad_update_fallback(peripheral);
+}
+
+void Macro::set_pad_update_fallback(PadUpdateFallback fallback) {
+    player_pad_update_fallback = fallback;
 }
 
 void Macro::prepare_for_external_transition() {

--- a/src/mods/Macro.cpp
+++ b/src/mods/Macro.cpp
@@ -7441,37 +7441,51 @@ void Macro::on_gui_frame(int display) {
             }
 
             if (ImGui::CollapsingHeader(_("Keyboard Hotkeys"), ImGuiTreeNodeFlags_DefaultOpen) && m_hotkeys.size() >= 7) {
-                auto draw_macro_hotkey = [&](const char* action_label, uint32_t target, utility::Hotkey& hotkey) {
-                    ImGui::PushID((int)target);
-                    const auto label = hotkey_binds_label(hotkey.m_binds);
-                    ImGui::Text("%s: %s", action_label, label.c_str());
-                    ImGui::SameLine(sameLineWidth);
-                    if (ImGui::Button(_("Set"))) {
-                        capture_hotkey_target = target;
-                        hotkey.m_setting      = true;
-                        std::fill_n(raw_key_down, 256, false);
-                        set_playback_status("Press the new macro hotkey.");
-                    }
-                    ImGui::SameLine();
-                    if (ImGui::Button(_("Clear"))) {
-                        hotkey.m_binds   = hotkey.m_default_keys;
-                        hotkey.m_setting = false;
-                        if (capture_hotkey_target == target) {
-                            capture_hotkey_target = 0;
-                        }
-                        update_config_hotkey_vkeys(m_hotkeys);
-                        set_playback_status("Macro hotkey restored to default.");
-                    }
-                    ImGui::PopID();
-                };
+                const float set_width = ImGui::CalcTextSize(_("Set")).x + ImGui::GetStyle().FramePadding.x * 2.0f;
+                const float clear_width = ImGui::CalcTextSize(_("Clear")).x + ImGui::GetStyle().FramePadding.x * 2.0f;
+                if (ImGui::BeginTable(
+                        "##MacroKeyboardHotkeys",
+                        3,
+                        ImGuiTableFlags_SizingStretchProp | ImGuiTableFlags_NoSavedSettings)) {
+                    ImGui::TableSetupColumn("##Action", ImGuiTableColumnFlags_WidthStretch);
+                    ImGui::TableSetupColumn("##Set", ImGuiTableColumnFlags_WidthFixed, set_width);
+                    ImGui::TableSetupColumn("##Clear", ImGuiTableColumnFlags_WidthFixed, clear_width);
 
-                draw_macro_hotkey(_("Play Macro"), 1, *m_hotkeys[0]);
-                draw_macro_hotkey(_("Stop Macro / Clear Input"), 2, *m_hotkeys[1]);
-                draw_macro_hotkey(_("Capture Snapshot"), 3, *m_hotkeys[2]);
-                draw_macro_hotkey(_("Load Snapshot"), 4, *m_hotkeys[3]);
-                draw_macro_hotkey(_("Load Snapshot + Play Macro"), 5, *m_hotkeys[4]);
-                draw_macro_hotkey(_("Load Setup"), 6, *m_hotkeys[5]);
-                draw_macro_hotkey(_("Load Setup + Play Macro"), 7, *m_hotkeys[6]);
+                    auto draw_macro_hotkey = [&](const char* action_label, uint32_t target, utility::Hotkey& hotkey) {
+                        ImGui::PushID((int)target);
+                        ImGui::TableNextRow();
+                        ImGui::TableSetColumnIndex(0);
+                        const auto label = hotkey_binds_label(hotkey.m_binds);
+                        ImGui::TextWrapped("%s: %s", action_label, label.c_str());
+                        ImGui::TableSetColumnIndex(1);
+                        if (ImGui::Button(_("Set"), ImVec2(-FLT_MIN, 0.0f))) {
+                            capture_hotkey_target = target;
+                            hotkey.m_setting      = true;
+                            std::fill_n(raw_key_down, 256, false);
+                            set_playback_status("Press the new macro hotkey.");
+                        }
+                        ImGui::TableSetColumnIndex(2);
+                        if (ImGui::Button(_("Clear"), ImVec2(-FLT_MIN, 0.0f))) {
+                            hotkey.m_binds   = hotkey.m_default_keys;
+                            hotkey.m_setting = false;
+                            if (capture_hotkey_target == target) {
+                                capture_hotkey_target = 0;
+                            }
+                            update_config_hotkey_vkeys(m_hotkeys);
+                            set_playback_status("Macro hotkey restored to default.");
+                        }
+                        ImGui::PopID();
+                    };
+
+                    draw_macro_hotkey(_("Play Macro"), 1, *m_hotkeys[0]);
+                    draw_macro_hotkey(_("Stop Macro / Clear Input"), 2, *m_hotkeys[1]);
+                    draw_macro_hotkey(_("Capture Snapshot"), 3, *m_hotkeys[2]);
+                    draw_macro_hotkey(_("Load Snapshot"), 4, *m_hotkeys[3]);
+                    draw_macro_hotkey(_("Load Snapshot + Play Macro"), 5, *m_hotkeys[4]);
+                    draw_macro_hotkey(_("Load Setup"), 6, *m_hotkeys[5]);
+                    draw_macro_hotkey(_("Load Setup + Play Macro"), 7, *m_hotkeys[6]);
+                    ImGui::EndTable();
+                }
 
                 if (capture_hotkey_target != 0) {
                     ImGui::TextWrapped(_("Capturing hotkey: press a non-modifier key. Ctrl, Shift, and Alt are captured as modifiers."));
@@ -7496,24 +7510,41 @@ void Macro::on_gui_frame(int display) {
                     _("Load Setup + Play"),
                 };
 
-                for (uint32_t index = 0; index < GAMEPAD_HOTKEY_COUNT; ++index) {
-                    ImGui::PushID((int)(100 + index));
-                    ImGui::Text("%s: Back/Select + %s", gamepad_action_labels[index], gamepad_hotkey_button_label(gamepad_hotkey_buttons[index]));
-                    ImGui::SameLine(sameLineWidth);
-                    if (ImGui::Button(_("Set"))) {
-                        capture_gamepad_hotkey_target = index + 1;
-                        gamepad_hotkey_raw_buttons = 0;
-                        set_playback_status("Hold Back/Select and press the new gamepad hotkey button.");
-                    }
-                    ImGui::SameLine();
-                    if (ImGui::Button(_("Clear"))) {
-                        gamepad_hotkey_buttons[index] = DEFAULT_GAMEPAD_HOTKEY_BUTTONS[index];
-                        if (capture_gamepad_hotkey_target == index + 1) {
-                            capture_gamepad_hotkey_target = 0;
+                const float set_width = ImGui::CalcTextSize(_("Set")).x + ImGui::GetStyle().FramePadding.x * 2.0f;
+                const float clear_width = ImGui::CalcTextSize(_("Clear")).x + ImGui::GetStyle().FramePadding.x * 2.0f;
+                if (ImGui::BeginTable(
+                        "##MacroGamepadHotkeys",
+                        3,
+                        ImGuiTableFlags_SizingStretchProp | ImGuiTableFlags_NoSavedSettings)) {
+                    ImGui::TableSetupColumn("##Action", ImGuiTableColumnFlags_WidthStretch);
+                    ImGui::TableSetupColumn("##Set", ImGuiTableColumnFlags_WidthFixed, set_width);
+                    ImGui::TableSetupColumn("##Clear", ImGuiTableColumnFlags_WidthFixed, clear_width);
+
+                    for (uint32_t index = 0; index < GAMEPAD_HOTKEY_COUNT; ++index) {
+                        ImGui::PushID((int)(100 + index));
+                        ImGui::TableNextRow();
+                        ImGui::TableSetColumnIndex(0);
+                        ImGui::TextWrapped(
+                            "%s: Back/Select + %s",
+                            gamepad_action_labels[index],
+                            gamepad_hotkey_button_label(gamepad_hotkey_buttons[index]));
+                        ImGui::TableSetColumnIndex(1);
+                        if (ImGui::Button(_("Set"), ImVec2(-FLT_MIN, 0.0f))) {
+                            capture_gamepad_hotkey_target = index + 1;
+                            gamepad_hotkey_raw_buttons = 0;
+                            set_playback_status("Hold Back/Select and press the new gamepad hotkey button.");
                         }
-                        set_playback_status("Gamepad hotkey restored to default.");
+                        ImGui::TableSetColumnIndex(2);
+                        if (ImGui::Button(_("Clear"), ImVec2(-FLT_MIN, 0.0f))) {
+                            gamepad_hotkey_buttons[index] = DEFAULT_GAMEPAD_HOTKEY_BUTTONS[index];
+                            if (capture_gamepad_hotkey_target == index + 1) {
+                                capture_gamepad_hotkey_target = 0;
+                            }
+                            set_playback_status("Gamepad hotkey restored to default.");
+                        }
+                        ImGui::PopID();
                     }
-                    ImGui::PopID();
+                    ImGui::EndTable();
                 }
 
                 if (capture_gamepad_hotkey_target != 0) {

--- a/src/mods/Macro.hpp
+++ b/src/mods/Macro.hpp
@@ -61,6 +61,8 @@ struct MacroClip {
 
 class Macro : public Mod {
 public:
+    using PadUpdateFallback = bool(__stdcall*)(cPeripheral* peripheral);
+
     Macro() = default;
     std::string get_mod_name() override { return "Macro"; };
 
@@ -98,9 +100,12 @@ public:
     static std::vector<MacroClip> playback_clips;
     static std::vector<MacroFrame> playback_frames;
     static std::vector<MacroSourceLine> playback_source_lines;
+    static uintptr_t player_pad_jmp_ret;
 
+    static bool __stdcall dispatch_player_pad_update(cPeripheral* peripheral);
     static void __stdcall on_pad_update_tick(cPeripheral* peripheral);
     static void __stdcall on_player_pad_update(cPeripheral* peripheral);
+    static void set_pad_update_fallback(PadUpdateFallback fallback);
 
     std::optional<std::string> on_initialize() override;
     void on_frame(fmilliseconds& dt) override;
@@ -115,6 +120,8 @@ public:
     static void prepare_for_external_transition();
 
 private:
+    std::unique_ptr<FunctionHook> player_pad_hook;
+
     static void write_test_input(cPeripheral* peripheral, uint32_t player_index);
     static void reset_input_state();
     static bool load_playback_file();


### PR DESCRIPTION
- fixes Macro input in public builds by moving the shared player input hook out of Coop
- keeps Coop input handling as an optional development-only fallback
- fixes Macro hotkey rows with longer translations
- fixes Animation Overlay label spacing and duplicated Move Part text
- updates the browser-ready Macro guides and adds a starter macro.txt